### PR TITLE
Implement filtering by the task name

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -41,6 +41,27 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code phrase} contains the given fragment {@code fragment}. Ignores case.
+     * <br>examples:<pre>
+     *       containsWordIgnoreCase("ABc def", "abc") == true
+     *       containsWordIgnoreCase("ABc def", "DEF") == true
+     *       containsWordIgnoreCase("ABc def", "AB") == true
+     *       </pre>
+     *
+     * @param phrase cannot be null
+     * @param fragment cannot be null or empty
+     */
+    public static boolean containsFragmentIgnoreCase(String phrase, String fragment) {
+        requireNonNull(phrase);
+        requireNonNull(fragment);
+
+        fragment = fragment.trim();
+        checkArgument(!fragment.isEmpty(), "Word parameter cannot be empty");
+
+        return phrase.contains(fragment);
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -58,7 +58,20 @@ public class StringUtil {
         fragment = fragment.trim();
         checkArgument(!fragment.isEmpty(), "Word parameter cannot be empty");
 
-        return phrase.contains(fragment);
+        return containsIgnoreCase(phrase, fragment);
+    }
+
+    /**
+     * Like String.contains, but ignoring case.
+     *
+     * @param phrase cannot be null
+     * @param fragment cannot be null
+     */
+    public static boolean containsIgnoreCase(String phrase, String fragment) {
+        requireNonNull(phrase);
+        requireNonNull(fragment);
+
+        return phrase.toLowerCase().contains(fragment.toLowerCase());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Name;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
@@ -64,6 +65,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
 
         try {
             switch (key) {
+            case "n": // fallthrough
+            case "name": {
+                Predicate<Name> namePredicate = Name.makeFilter(operator, testPhrase);
+                predicate = task -> namePredicate.test(task.getName());
+                break;
+            }
             case "d": // fallthrough
             case "due": {
                 Predicate<Deadline> deadlinePredicate = Deadline.makeFilter(operator, testPhrase);

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -44,7 +44,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         // due=1/10/2018
         // test<blah
         // name>"hello world"
-        Pattern pattern = Pattern.compile("^([a-zA-Z]+)\\s*([\\=\\<\\>])\\s*(\".+?\"|\'.+?\'|[\\S&&[^\"\']]+)$");
+        Pattern pattern = Pattern.compile("^([a-zA-Z]+)\\s*([\\=\\<\\>\\:])\\s*(\".+?\"|\'.+?\'|[\\S&&[^\"\']]+)$");
         Matcher matcher = pattern.matcher(trimmedArgs);
 
         if (!matcher.matches() || matcher.groupCount() != 3) {

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -66,6 +66,7 @@ public class Deadline implements Comparable<Deadline> {
         switch (operator) {
         case "=":
             return deadline -> deadline.equals(testDeadline);
+        case ":": // convenience operator, works the same as "<"
         case "<":
             return deadline -> deadline.compareTo(testDeadline) <= 0;
         case ">":

--- a/src/main/java/seedu/address/model/task/Name.java
+++ b/src/main/java/seedu/address/model/task/Name.java
@@ -1,5 +1,11 @@
 package seedu.address.model.task;
 
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
+import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
+
+import java.util.function.Predicate;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
@@ -18,7 +24,7 @@ public class Name {
      */
     public static final String NAME_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
-    public final String fullName;
+    public final String value;
 
     /**
      * Constructs a {@code Name}.
@@ -28,7 +34,7 @@ public class Name {
     public Name(String name) {
         requireNonNull(name);
         checkArgument(isValidName(name), MESSAGE_NAME_CONSTRAINTS);
-        fullName = name;
+        value = name;
     }
 
     /**
@@ -38,22 +44,41 @@ public class Name {
         return test.matches(NAME_VALIDATION_REGEX);
     }
 
+    /**
+     * Constructs a predicate from the given operator and test phrase.
+     *
+     * @param operator The operator for this predicate.
+     * @param testPhrase The test phrase for this predicate.
+     */
+    public static Predicate<Name> makeFilter(String operator, String testPhrase) throws InvalidPredicateOperatorException {
+        switch (operator) {
+        case "=":
+            return name -> name.value.equals(testPhrase);
+        case "<":
+            return name -> StringUtil.containsFragmentIgnoreCase(testPhrase, name.value);
+        case ">":
+            return name -> StringUtil.containsFragmentIgnoreCase(name.value, testPhrase);
+        default:
+            throw new InvalidPredicateOperatorException();
+        }
+    }
+
 
     @Override
     public String toString() {
-        return fullName;
+        return value;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof Name // instanceof handles nulls
-            && fullName.equals(((Name) other).fullName)); // state check
+            && value.equals(((Name) other).value)); // state check
     }
 
     @Override
     public int hashCode() {
-        return fullName.hashCode();
+        return value.hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/task/Name.java
+++ b/src/main/java/seedu/address/model/task/Name.java
@@ -1,13 +1,12 @@
 package seedu.address.model.task;
 
-import seedu.address.commons.util.StringUtil;
-import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
-import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.function.Predicate;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
 
 /**
  * Represents a Task's name in the deadline manager. Guarantees: immutable; is valid as declared in
@@ -50,7 +49,8 @@ public class Name {
      * @param operator The operator for this predicate.
      * @param testPhrase The test phrase for this predicate.
      */
-    public static Predicate<Name> makeFilter(String operator, String testPhrase) throws InvalidPredicateOperatorException {
+    public static Predicate<Name> makeFilter(String operator, String testPhrase)
+            throws InvalidPredicateOperatorException {
         switch (operator) {
         case "=":
             return name -> name.value.equals(testPhrase);

--- a/src/main/java/seedu/address/model/task/Name.java
+++ b/src/main/java/seedu/address/model/task/Name.java
@@ -56,6 +56,7 @@ public class Name {
             return name -> name.value.equals(testPhrase);
         case "<":
             return name -> StringUtil.containsFragmentIgnoreCase(testPhrase, name.value);
+        case ":": // convenience operator, works the same as ">"
         case ">":
             return name -> StringUtil.containsFragmentIgnoreCase(name.value, testPhrase);
         default:

--- a/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/NameContainsKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Task> {
     public boolean test(Task task) {
         return keywords.stream()
             .anyMatch(keyword -> StringUtil
-                .containsWordIgnoreCase(task.getName().fullName, keyword));
+                .containsWordIgnoreCase(task.getName().value, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -62,7 +62,7 @@ public class XmlAdaptedTask {
      * @param source future changes to this will not affect the created XmlAdaptedTask
      */
     public XmlAdaptedTask(Task source) {
-        name = source.getName().fullName;
+        name = source.getName().value;
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -42,7 +42,7 @@ public class BrowserPanel extends UiPart<Region> {
     }
 
     private void loadPersonPage(Task task) {
-        loadPage(SEARCH_PAGE_URL + task.getName().fullName);
+        loadPage(SEARCH_PAGE_URL + task.getName().value);
     }
 
     public void loadPage(String url) {

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -44,7 +44,7 @@ public class TaskCard extends UiPart<Region> {
         super(FXML);
         this.task = task;
         id.setText(displayedIndex + ". ");
-        name.setText(task.getName().fullName);
+        name.setText(task.getName().value);
         phone.setText(task.getPhone().value);
         address.setText(task.getAddress().value);
         email.setText(task.getEmail().value);

--- a/src/test/java/guitests/guihandles/TaskCardHandle.java
+++ b/src/test/java/guitests/guihandles/TaskCardHandle.java
@@ -77,7 +77,7 @@ public class TaskCardHandle extends NodeHandle<Node> {
      * Returns true if this handle contains {@code task}.
      */
     public boolean equals(Task task) {
-        return getName().equals(task.getName().fullName)
+        return getName().equals(task.getName().value)
             && getAddress().equals(task.getAddress().value)
             && getPhone().equals(task.getPhone().value)
             && getEmail().equals(task.getEmail().value)

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -130,7 +130,7 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Task task = model.getFilteredPersonList().get(targetIndex.getZeroBased());
-        final String[] splitName = task.getName().fullName.split("\\s+");
+        final String[] splitName = task.getName().value.split("\\s+");
         model.updateFilteredPersonList(
             new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -33,6 +33,15 @@ public class FilterCommandParserTest {
         assertParseSuccess(parser, "d <01/02/19");
         assertParseSuccess(parser, "d< 01/02/19");
         assertParseSuccess(parser, "d<01/02/19");
+        assertParseSuccess(parser, "d:01/02/19");
+
+        assertParseSuccess(parser, "n>Hello");
+        assertParseSuccess(parser, "n>\"Hello\"");
+        assertParseSuccess(parser, "n>\"Hello World\"");
+        assertParseSuccess(parser, "n=\"Hello World\"");
+        assertParseSuccess(parser, "n:\"Hello World\"");
+        assertParseSuccess(parser, "n<\"Hello World\"");
+        assertParseSuccess(parser, "n:Test");
     }
 
     @Test
@@ -53,6 +62,10 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "-");
         assertParseThrowsException(parser, "test=test");
         assertParseThrowsException(parser, "=test");
+        assertParseThrowsException(parser, "name>");
+        assertParseThrowsException(parser, "name<");
+        assertParseThrowsException(parser, "name~");
+        assertParseThrowsException(parser, "name:");
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -45,6 +45,12 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "d<\'\'30/9/17");
         assertParseThrowsException(parser, "d<30/9/17\'\'");
         assertParseThrowsException(parser, "d<");
+        assertParseThrowsException(parser, "d=");
+        assertParseThrowsException(parser, "d>");
+        assertParseThrowsException(parser, "d");
+        assertParseThrowsException(parser, "=");
+        assertParseThrowsException(parser, ":");
+        assertParseThrowsException(parser, "-");
         assertParseThrowsException(parser, "test=test");
         assertParseThrowsException(parser, "=test");
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -71,7 +71,7 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(differentTaskCollection, userPrefs)));
 
         // different filteredList -> returns false
-        String[] keywords = ALICE.getName().fullName.split("\\s+");
+        String[] keywords = ALICE.getName().value.split("\\s+");
         modelManager.updateFilteredPersonList(
             new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(taskCollection, userPrefs)));

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -30,7 +30,7 @@ public class PersonUtil {
      */
     public static String getPersonDetails(Task task) {
         StringBuilder sb = new StringBuilder();
-        sb.append(PREFIX_NAME + task.getName().fullName + " ");
+        sb.append(PREFIX_NAME + task.getName().value + " ");
         sb.append(PREFIX_PHONE + task.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + task.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + task.getAddress().value + " ");
@@ -46,7 +46,7 @@ public class PersonUtil {
     public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getName()
-            .ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
+            .ifPresent(name -> sb.append(PREFIX_NAME).append(name.value).append(" "));
         descriptor.getPhone()
             .ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail()

--- a/src/test/java/seedu/address/ui/BrowserPanelTest.java
+++ b/src/test/java/seedu/address/ui/BrowserPanelTest.java
@@ -42,7 +42,7 @@ public class BrowserPanelTest extends GuiUnitTest {
         // associated web page of a task
         postNow(selectionChangedEventStub);
         URL expectedPersonUrl = new URL(
-            BrowserPanel.SEARCH_PAGE_URL + ALICE.getName().fullName.replaceAll(" ", "%20"));
+            BrowserPanel.SEARCH_PAGE_URL + ALICE.getName().value.replaceAll(" ", "%20"));
 
         waitUntilBrowserLoaded(browserPanelHandle);
         assertEquals(expectedPersonUrl, browserPanelHandle.getLoadedUrl());

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -32,7 +32,7 @@ public class GuiTestAssert {
      * Asserts that {@code actualCard} displays the details of {@code expectedTask}.
      */
     public static void assertCardDisplaysPerson(Task expectedTask, TaskCardHandle actualCard) {
-        assertEquals(expectedTask.getName().fullName, actualCard.getName());
+        assertEquals(expectedTask.getName().value, actualCard.getName());
         assertEquals(expectedTask.getPhone().value, actualCard.getPhone());
         assertEquals(expectedTask.getEmail().value, actualCard.getEmail());
         assertEquals(expectedTask.getAddress().value, actualCard.getAddress());

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -137,7 +137,7 @@ public class FindCommandSystemTest extends TaskCollectionSystemTest {
         showAllPersons();
         selectPerson(Index.fromOneBased(1));
         assertFalse(getPersonListPanel().getHandleToSelectedCard().getName()
-            .equals(DANIEL.getName().fullName));
+            .equals(DANIEL.getName().value));
         command = FindCommand.COMMAND_WORD + " Daniel";
         ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);


### PR DESCRIPTION
Users can search the tasks using any substring (not necessarily whole word) of the task name.  it is case-insensitive, and it even works with quoted strings that contain spaces, e.g. **filter n:"x y"** matches the name "Alex Yeoh".

The convenience operator ":" is implemented for Name and Deadline, and it is meant to be an alias for the operator that users (especially inexperienced users) most likely want for any given field.

Relevant tests have also been updated.