### PR TITLE
Filter: Support filtering by tags

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -2,12 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.FilterOperator;
 import seedu.address.model.task.Name;
@@ -15,6 +17,7 @@ import seedu.address.model.task.Task;
 import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
 import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
+import seedu.address.model.util.SetUtil;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -76,6 +79,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             case "due": {
                 Predicate<Deadline> deadlinePredicate = Deadline.makeFilter(operator, testPhrase);
                 predicate = task -> deadlinePredicate.test(task.getDeadline());
+                break;
+            }
+            case "t": // fallthrough
+            case "tag": {
+                Predicate<Set<Tag>> tagsPredicate = SetUtil.makeFilter(Tag.class, operator, testPhrase);
+                predicate = task -> tagsPredicate.test(task.getTags());
                 break;
             }
             default:

--- a/src/main/java/seedu/address/logic/parser/StringTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/StringTokenizer.java
@@ -1,0 +1,125 @@
+package seedu.address.logic.parser;
+
+import java.util.ArrayList;
+import java.util.InputMismatchException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class tokenizes a string.
+ * The token can be any predicate,
+ * and it supports quoted strings (and arbitrary levels of recursiveness) too.
+ * It is better than java.util.StringTokenizer.
+ * Multiple consecutive delimiters are treated as a single delimiter.
+ */
+public class StringTokenizer {
+    private final String str;
+    private final Predicate<Character> delimPred;
+    private final Predicate<Character> quotePred;
+    private int nextIndex;
+
+    public StringTokenizer(String str, Predicate<Character> delimPred, Predicate<Character> quotePred) {
+        this.str = str;
+        this.delimPred = delimPred;
+        this.quotePred = quotePred;
+        this.nextIndex = 0;
+    }
+
+    /**
+     * Returns true if there are still non-delimiter characters in the string.
+     */
+    public boolean hasNextToken() {
+        // gobble up all the delims
+        while (nextIndex < str.length() && delimPred.test(str.charAt(nextIndex))) {
+            ++nextIndex;
+        }
+
+        return nextIndex < str.length();
+    }
+
+    /**
+     * Consume the next tokens.
+     */
+    public String nextString() {
+        if (!hasNextToken()) {
+            throw new NoSuchElementException("Reached end of string while reading delimiter!");
+        }
+
+        int startLocation = nextIndex;
+        if (quotePred.test(str.charAt(nextIndex))) {
+            // starts with quote
+            char quote = str.charAt(nextIndex);
+            boolean hasEndedWithQuote = false;
+            for (++nextIndex; nextIndex < str.length(); ++nextIndex) {
+                char ch = str.charAt(nextIndex);
+                if (quote == ch) {
+                    // matching quote, break
+                    hasEndedWithQuote = true;
+                    ++nextIndex;
+                    break;
+                }
+            }
+            if (hasEndedWithQuote) {
+                // successful read of quoted string
+                assert quotePred.test(str.charAt(startLocation)) && quotePred.test(str.charAt(nextIndex - 1)) : "String did not start or end with quotes!";
+                // remove leading/trailing quote before returning
+                String ret = str.substring(startLocation + 1, nextIndex - 1);
+                return ret;
+            } else {
+                // bad, we ran out of characters
+                // rollback nextIndex
+                nextIndex = startLocation;
+                // throw an exception
+                throw new InputMismatchException("Reached end of string while reading quoted string!");
+            }
+        } else {
+            // does not start with quote
+            // there should be no quotes within this string
+            for (; nextIndex < str.length(); ++nextIndex) {
+                char ch = str.charAt(nextIndex);
+                if (delimPred.test(ch)) {
+                    break;
+                } else if (quotePred.test(ch)) {
+                    // rollback nextIndex
+                    nextIndex = startLocation;
+                    // throw an exception
+                    throw new InputMismatchException("Quotes encountered in the middle of unquoted string!");
+                }
+            }
+            return str.substring(startLocation, nextIndex);
+        }
+    }
+
+    /**
+     * Consume the next token specified with the regex.
+     */
+    public String nextPattern(Pattern pattern) {
+        if (!hasNextToken()) {
+            throw new NoSuchElementException("Reached end of string while reading delimiter!");
+        }
+
+        Matcher matcher = pattern.matcher(str.subSequence(nextIndex, str.length()));
+
+        if (!matcher.matches() || matcher.start() != 0) {
+            throw new InputMismatchException("The next token does not match the given pattern!");
+        }
+
+        nextIndex += matcher.end();
+
+        return matcher.group();
+    }
+
+    /**
+     * Gets all the tokens from this tokenizer.
+     */
+    public List<String> toList() {
+        ArrayList<String> items = new ArrayList<>();
+        while (hasNextToken()) {
+            items.add(nextString());
+        }
+        return items;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/StringTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/StringTokenizer.java
@@ -64,7 +64,8 @@ public class StringTokenizer {
             }
             if (hasEndedWithQuote) {
                 // successful read of quoted string
-                assert quotePred.test(str.charAt(startLocation)) && quotePred.test(str.charAt(nextIndex - 1)) : "String did not start or end with quotes!";
+                assert quotePred.test(str.charAt(startLocation)) && quotePred.test(str.charAt(nextIndex - 1))
+                    : "String did not start or end with quotes!";
                 // remove leading/trailing quote before returning
                 String ret = str.substring(startLocation + 1, nextIndex - 1);
                 return ret;

--- a/src/main/java/seedu/address/model/util/SetUtil.java
+++ b/src/main/java/seedu/address/model/util/SetUtil.java
@@ -34,8 +34,8 @@ public class SetUtil {
             Set<T> items = tokenizer.toList().stream().map(token -> {
                 try {
                     return klass.getDeclaredConstructor(String.class).newInstance(token);
-                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
-                    InvocationTargetException e) {
+                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+                    | InvocationTargetException e) {
                     throw new IllegalArgumentException("Class does not support construction from a single string", e);
                 }
             }).collect(Collectors.toSet());

--- a/src/main/java/seedu/address/model/util/SetUtil.java
+++ b/src/main/java/seedu/address/model/util/SetUtil.java
@@ -1,0 +1,56 @@
+package seedu.address.model.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.InputMismatchException;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import seedu.address.logic.parser.StringTokenizer;
+import seedu.address.model.task.FilterOperator;
+import seedu.address.model.task.exceptions.InvalidPredicateException;
+import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
+import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
+
+/**
+ * Contains utility methods for manipulating Sets.
+ * It is currently used to make filters for tags and attachments.
+ */
+public class SetUtil {
+    /**
+     * Constructs a predicate from the given operator and test phrase.
+     * Test phrase should be a comma-separated list of values.
+     *
+     * @param klass      The class that this filter is being made for.
+     * @param operator   The operator for this predicate.
+     * @param testPhrase The test phrase for this predicate.
+     */
+    public static <T> Predicate<Set<T>> makeFilter(Class<T> klass, FilterOperator operator, String testPhrase)
+        throws InvalidPredicateException {
+        try {
+            // comma-separated quotable tokenizer
+            StringTokenizer tokenizer = new StringTokenizer(testPhrase, ch -> ch == ',', ch -> ch == '\'' || ch == '\"');
+            Set<T> items = tokenizer.toList().stream().map(token -> {
+                try {
+                    return klass.getDeclaredConstructor(String.class).newInstance(token);
+                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                    throw new IllegalArgumentException("Class does not support construction from a single string", e);
+                }
+            }).collect(Collectors.toSet());
+            switch (operator) {
+            case EQUAL:
+                return set -> set.equals(items);
+            case LESS:
+                return set -> set.stream().allMatch(item -> items.contains(item));
+            case CONVENIENCE: // convenience operator, works the same as ">"
+            case GREATER:
+                return set -> items.stream().allMatch(item -> set.contains(item));
+            default:
+                throw new InvalidPredicateOperatorException();
+            }
+        } catch (InputMismatchException e) {
+            throw new InvalidPredicateTestPhraseException(e);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/util/SetUtil.java
+++ b/src/main/java/seedu/address/model/util/SetUtil.java
@@ -5,7 +5,6 @@ import java.util.InputMismatchException;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import seedu.address.logic.parser.StringTokenizer;
 import seedu.address.model.task.FilterOperator;
@@ -30,11 +29,13 @@ public class SetUtil {
         throws InvalidPredicateException {
         try {
             // comma-separated quotable tokenizer
-            StringTokenizer tokenizer = new StringTokenizer(testPhrase, ch -> ch == ',', ch -> ch == '\'' || ch == '\"');
+            StringTokenizer tokenizer = new StringTokenizer(testPhrase,
+                ch -> ch == ',', ch -> ch == '\'' || ch == '\"');
             Set<T> items = tokenizer.toList().stream().map(token -> {
                 try {
                     return klass.getDeclaredConstructor(String.class).newInstance(token);
-                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+                    InvocationTargetException e) {
                     throw new IllegalArgumentException("Class does not support construction from a single string", e);
                 }
             }).collect(Collectors.toSet());


### PR DESCRIPTION
This will resolve #39.

A generalized string tokenizer class has been created to split the input tag list.  Its design is intended to be general enough to support tokenization for the requirements for #40.

A utility class has also been created to provide set-based filter predicates.

~~Note: This PR has been rebased on top of #69.  Merge #69 first.~~