### PR TITLE
Attachments: Add ability to save attachment information to XML storage

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -107,7 +107,9 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(taskToEdit.getAddress());
         Deadline updatedDeadline = editPersonDescriptor.getDeadline().orElse(taskToEdit.getDeadline());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(taskToEdit.getTags());
-        Set<Attachment> updatedAttachments = editPersonDescriptor.getAttachments().orElse(taskToEdit.getAttachments());
+
+        // Attachments are not modifiable via 'EditCommand'
+        Set<Attachment> updatedAttachments = taskToEdit.getAttachments();
 
         return new Task(updatedName, updatedPhone, updatedPriority, updatedEmail, updatedDeadline,
             updatedAddress, updatedTags, updatedAttachments);
@@ -144,12 +146,10 @@ public class EditCommand extends Command {
         private Address address;
         private Deadline deadline;
         private Set<Tag> tags;
-        private Set<Attachment> attachments;
 
         public EditPersonDescriptor() {
             // TODO: Fix EditCommandParser.java, these lines are just to pass tests
             deadline = new Deadline(new GregorianCalendar(2018, 10, 1).getTime());
-            attachments = new HashSet<>();
         }
 
         /**
@@ -163,7 +163,6 @@ public class EditCommand extends Command {
             setDeadline(toCopy.deadline);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
-            setAttachments(toCopy.attachments);
         }
 
         /**
@@ -238,23 +237,6 @@ public class EditCommand extends Command {
                 : Optional.empty();
         }
 
-        /**
-         * Sets {@code attachments} to this object's {@code attachments}. A defensive copy of {@code attachments}
-         * is used internally.
-         */
-        public void setAttachments(Set<Attachment> attachments) {
-            this.attachments = (attachments != null) ? new HashSet<>(attachments) : null;
-        }
-
-        /**
-         * Returns an unmodifiable attachments set, which throws {@code UnsupportedOperationException} if
-         * modification is attempted. Returns {@code Optional#empty()} if {@code attachments} is null.
-         */
-        public Optional<Set<Attachment>> getAttachments() {
-            return (attachments != null) ? Optional.of(Collections.unmodifiableSet(attachments))
-                : Optional.empty();
-        }
-
         @Override
         public boolean equals(Object other) {
             // short circuit if same object
@@ -276,8 +258,7 @@ public class EditCommand extends Command {
                 && getEmail().equals(e.getEmail())
                 && getDeadline().equals(e.getDeadline())
                 && getAddress().equals(e.getAddress())
-                && getTags().equals(e.getTags())
-                && getAttachments().equals(e.getAttachments());
+                && getTags().equals(e.getTags());
         }
     }
 }

--- a/src/main/java/seedu/address/model/attachment/Attachment.java
+++ b/src/main/java/seedu/address/model/attachment/Attachment.java
@@ -26,12 +26,12 @@ public class Attachment {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof Attachment // instanceof handles nulls
-            && file.equals(((Attachment) other).file)); // state check
+            && file.getAbsolutePath().equals(((Attachment) other).file.getAbsolutePath())); // state check
     }
 
     @Override
     public int hashCode() {
-        return file.hashCode();
+        return file.getAbsolutePath().hashCode();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -46,11 +46,27 @@ public class Task {
     }
 
     /**
+     * Constructor without requiring attachments. Will set attachments to an empty set.
+     */
+    public Task(Name name, Phone phone, Priority priority, Email email, Deadline deadline, Address address,
+                Set<Tag> tags) {
+        requireAllNonNull(name, phone, priority, email, deadline, address, tags);
+        this.name = name;
+        this.phone = phone;
+        this.priority = priority;
+        this.email = email;
+        this.deadline = deadline;
+        this.address = address;
+        this.tags.addAll(tags);
+    }
+
+
+    /**
      * Convenience constructor, to be removed eventually
      */
     public Task(Name name, Phone phone, Priority priority, Email email, Address address, Set<Tag> tags) {
         this(name, phone, priority, email, new Deadline(new GregorianCalendar(2018, 10, 1).getTime()),
-            address, tags, new HashSet<Attachment>());
+            address, tags);
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -138,7 +138,6 @@ public class Task {
 
     @Override
     public String toString() {
-        // TODO: add deadline and attachments
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
             .append(" Phone: ")
@@ -153,6 +152,8 @@ public class Task {
             .append(getAddress())
             .append(" Tags: ");
         getTags().forEach(builder::append);
+        builder.append(" Attachments: ");
+        getAttachments().forEach(builder::append);
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,11 +1,13 @@
 package seedu.address.model.util;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.ReadOnlyTaskCollection;
 import seedu.address.model.TaskCollection;
+import seedu.address.model.attachment.Attachment;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Address;
 import seedu.address.model.task.Email;
@@ -65,4 +67,14 @@ public class SampleDataUtil {
             .collect(Collectors.toSet());
     }
 
+
+    /**
+     * Returns a attachment set containing the list of attachments given.
+     */
+    public static Set<Attachment> getAttachmentSet(String... strings) {
+        return Arrays.stream(strings)
+            .map(File::new)
+            .map(Attachment::new)
+            .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/seedu/address/storage/XmlAdaptedAttachment.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedAttachment.java
@@ -1,0 +1,63 @@
+package seedu.address.storage;
+
+import java.io.File;
+
+import javax.xml.bind.annotation.XmlValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.attachment.Attachment;
+
+/**
+ * JAXB-friendly adapted version of Attachment.
+ */
+public class XmlAdaptedAttachment {
+
+    @XmlValue
+    private String filePath;
+
+    /**
+     * Constructs an XmlAdaptedAttachment. This is the no-arg constructor that is required by JAXB.
+     */
+    public XmlAdaptedAttachment() {
+    }
+
+    /**
+     * Constructs a {@code XmlAdaptedAttachment} with the given {@code filePath}.
+     */
+    public XmlAdaptedAttachment(String filePath) {
+        this.filePath = filePath;
+    }
+
+    /**
+     * Converts a given Attachment into this class for JAXB use.
+     *
+     * @param source future changes to this will not affect the created
+     */
+    public XmlAdaptedAttachment(Attachment source) {
+        filePath = source.file.getAbsolutePath();
+    }
+
+    /**
+     * Converts this jaxb-friendly adapted tag object into the model's Tag object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted
+     *                               task
+     */
+    public Attachment toModelType() throws IllegalValueException {
+        //TODO: Check if attachment file exists
+        return new Attachment(new File(filePath));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedAttachment)) {
+            return false;
+        }
+
+        return filePath.equals(((XmlAdaptedAttachment) other).filePath);
+    }
+}

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -10,8 +11,10 @@ import java.util.stream.Collectors;
 import javax.xml.bind.annotation.XmlElement;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.attachment.Attachment;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Address;
+import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Email;
 import seedu.address.model.task.Name;
 import seedu.address.model.task.Phone;
@@ -38,6 +41,8 @@ public class XmlAdaptedTask {
 
     @XmlElement
     private List<XmlAdaptedTag> tagged = new ArrayList<>();
+    @XmlElement
+    private List<XmlAdaptedAttachment> attachments = new ArrayList<>();
 
     /**
      * Constructs an XmlAdaptedTask. This is the no-arg constructor that is required by JAXB.
@@ -49,7 +54,7 @@ public class XmlAdaptedTask {
      * Constructs an {@code XmlAdaptedTask} with the given task details.
      */
     public XmlAdaptedTask(String name, String phone, String priority, String email, String address,
-                          List<XmlAdaptedTag> tagged) {
+                          List<XmlAdaptedTag> tagged, List<XmlAdaptedAttachment> attachments) {
         this.name = name;
         this.phone = phone;
         this.priority = priority;
@@ -57,6 +62,9 @@ public class XmlAdaptedTask {
         this.address = address;
         if (tagged != null) {
             this.tagged = new ArrayList<>(tagged);
+        }
+        if (attachments != null) {
+            this.attachments = new ArrayList<>(attachments);
         }
     }
 
@@ -74,6 +82,9 @@ public class XmlAdaptedTask {
         tagged = source.getTags().stream()
             .map(XmlAdaptedTag::new)
             .collect(Collectors.toList());
+        attachments = source.getAttachments().stream()
+            .map(XmlAdaptedAttachment::new)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -83,10 +94,7 @@ public class XmlAdaptedTask {
      *                               task
      */
     public Task toModelType() throws IllegalValueException {
-        final List<Tag> personTags = new ArrayList<>();
-        for (XmlAdaptedTag tag : tagged) {
-            personTags.add(tag.toModelType());
-        }
+
 
         if (name == null) {
             throw new IllegalValueException(
@@ -133,8 +141,22 @@ public class XmlAdaptedTask {
         }
         final Address modelAddress = new Address(address);
 
-        final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Task(modelName, modelPhone, modelPriority, modelEmail, modelAddress, modelTags);
+        final List<Tag> taskTags = new ArrayList<>();
+        for (XmlAdaptedTag tag : tagged) {
+            taskTags.add(tag.toModelType());
+        }
+        final Set<Tag> modelTags = new HashSet<>(taskTags);
+
+        final List<Attachment> taskAttachments = new ArrayList<>();
+        for (XmlAdaptedAttachment attachment : attachments) {
+            taskAttachments.add(attachment.toModelType());
+        }
+        final Set<Attachment> modelAttachments = new HashSet<>(taskAttachments);
+
+        final Deadline tempDeadline = new Deadline(new GregorianCalendar(2018, 10, 1).getTime());
+
+        return new Task(modelName, modelPhone, modelPriority, modelEmail,
+            tempDeadline, modelAddress, modelTags, modelAttachments);
     }
 
     @Override
@@ -153,6 +175,7 @@ public class XmlAdaptedTask {
             && Objects.equals(priority, otherPerson.priority)
             && Objects.equals(email, otherPerson.email)
             && Objects.equals(address, otherPerson.address)
-            && tagged.equals(otherPerson.tagged);
+            && tagged.equals(otherPerson.tagged)
+            && attachments.equals(otherPerson.attachments);
     }
 }

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -1,7 +1,6 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -153,7 +152,7 @@ public class XmlAdaptedTask {
         }
         final Set<Attachment> modelAttachments = new HashSet<>(taskAttachments);
 
-        final Deadline tempDeadline = new Deadline(new GregorianCalendar(2018, 10, 1).getTime());
+        final Deadline tempDeadline = new Deadline("1/10/2018");
 
         return new Task(modelName, modelPhone, modelPriority, modelEmail,
             tempDeadline, modelAddress, modelTags, modelAttachments);

--- a/src/test/data/XmlSerializableTaskCollectionTest/typicalTasksInTaskCollection.xml
+++ b/src/test/data/XmlSerializableTaskCollectionTest/typicalTasksInTaskCollection.xml
@@ -8,6 +8,8 @@
         <email>alice@example.com</email>
         <address>123, Jurong West Ave 6, #08-111</address>
         <tagged>friends</tagged>
+        <attachments>hello.txt</attachments>
+        <attachments>world.txt</attachments>
     </tasks>
     <tasks>
         <name>Benson Meier</name>
@@ -17,6 +19,8 @@
         <address>311, Clementi Ave 2, #02-25</address>
         <tagged>owesMoney</tagged>
         <tagged>friends</tagged>
+        <attachments>hello.txt</attachments>
+        <attachments>world.txt</attachments>
     </tasks>
     <tasks>
         <name>Carl Kurz</name>
@@ -24,6 +28,7 @@
         <priority>3</priority>
         <email>heinz@example.com</email>
         <address>wall street</address>
+        <attachments>world.txt</attachments>
     </tasks>
     <tasks>
         <name>Daniel Meier</name>
@@ -46,6 +51,8 @@
         <priority>2</priority>
         <email>lydia@example.com</email>
         <address>little tokyo</address>
+        <attachments>hello.txt</attachments>
+        <attachments>world.txt</attachments>
     </tasks>
     <tasks>
         <name>George Best</name>
@@ -53,5 +60,6 @@
         <priority>3</priority>
         <email>anna@example.com</email>
         <address>4th street</address>
+        <attachments>hello.txt</attachments>
     </tasks>
 </taskcollection>

--- a/src/test/data/XmlUtilTest/invalidTaskField.xml
+++ b/src/test/data/XmlUtilTest/invalidTaskField.xml
@@ -7,4 +7,5 @@
     <email>hans@example</email>
     <address>4th street</address>
     <tagged>friends</tagged>
+    <attachments>hello.txt</attachments>
 </task>

--- a/src/test/data/XmlUtilTest/missingTaskField.xml
+++ b/src/test/data/XmlUtilTest/missingTaskField.xml
@@ -6,4 +6,5 @@
     <email>hans@example</email>
     <address>4th street</address>
     <tagged>friends</tagged>
+    <attachments>hello.txt</attachments>
 </task>

--- a/src/test/data/XmlUtilTest/validTask.xml
+++ b/src/test/data/XmlUtilTest/validTask.xml
@@ -6,4 +6,5 @@
     <email>hans@example</email>
     <address>4th street</address>
     <tagged>friends</tagged>
+    <attachments>hello.txt</attachments>
 </task>

--- a/src/test/data/XmlUtilTest/validTaskCollection.xml
+++ b/src/test/data/XmlUtilTest/validTaskCollection.xml
@@ -6,6 +6,7 @@
         <priority isPrivate="false">1</priority>
         <email isPrivate="false">hans@example.com</email>
         <address isPrivate="false">4th street</address>
+        <attachments>hello.txt</attachments>
     </tasks>
     <tasks>
         <name>Ruth Mueller</name>

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.model.TaskCollection;
+import seedu.address.storage.XmlAdaptedAttachment;
 import seedu.address.storage.XmlAdaptedTag;
 import seedu.address.storage.XmlAdaptedTask;
 import seedu.address.storage.XmlSerializableTaskCollection;
@@ -46,6 +47,8 @@ public class XmlUtilTest {
     private static final String VALID_ADDRESS = "4th street";
     private static final List<XmlAdaptedTag> VALID_TAGS = Collections
         .singletonList(new XmlAdaptedTag("friends"));
+    private static final List<XmlAdaptedAttachment> VALID_ATTACHMENTS = Collections
+        .singletonList(new XmlAdaptedAttachment("hello.txt"));
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -86,7 +89,7 @@ public class XmlUtilTest {
         XmlAdaptedTask actualPerson = XmlUtil.getDataFromFile(
             MISSING_PERSON_FIELD_FILE, XmlAdaptedTaskWithRootElement.class);
         XmlAdaptedTask expectedPerson = new XmlAdaptedTask(
-            null, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+            null, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_ATTACHMENTS);
         assertEquals(expectedPerson, actualPerson);
     }
 
@@ -95,7 +98,7 @@ public class XmlUtilTest {
         XmlAdaptedTask actualPerson = XmlUtil.getDataFromFile(
             INVALID_PERSON_FIELD_FILE, XmlAdaptedTaskWithRootElement.class);
         XmlAdaptedTask expectedPerson = new XmlAdaptedTask(
-            VALID_NAME, INVALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+            VALID_NAME, INVALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_ATTACHMENTS);
         assertEquals(expectedPerson, actualPerson);
     }
 
@@ -104,7 +107,7 @@ public class XmlUtilTest {
         XmlAdaptedTask actualPerson = XmlUtil.getDataFromFile(
             VALID_PERSON_FILE, XmlAdaptedTaskWithRootElement.class);
         XmlAdaptedTask expectedPerson = new XmlAdaptedTask(
-            VALID_NAME, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+            VALID_NAME, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_ATTACHMENTS);
         assertEquals(expectedPerson, actualPerson);
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -40,7 +40,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Task editedTask = new PersonBuilder().build();
+        // Preserve attachments as editedTask should have the same attachment
+        Task editedTask = new PersonBuilder()
+            .withAttachments(model.getFilteredPersonList().get(0).getAttachments())
+            .build();
+
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedTask).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
@@ -160,8 +164,10 @@ public class EditCommandTest {
 
     @Test
     public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
-        Task editedTask = new PersonBuilder().build();
         Task taskToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Task editedTask = new PersonBuilder()
+            .withAttachments(taskToEdit.getAttachments())
+            .build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedTask).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
         Model expectedModel = new ModelManager(new TaskCollection(model.getAddressBook()),
@@ -207,14 +213,16 @@ public class EditCommandTest {
      */
     @Test
     public void executeUndoRedo_validIndexFilteredList_samePersonEdited() throws Exception {
-        Task editedTask = new PersonBuilder().build();
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+        Task taskToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Task editedTask = new PersonBuilder()
+            .withAttachments(taskToEdit.getAttachments())
+            .build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedTask).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
         Model expectedModel = new ModelManager(new TaskCollection(model.getAddressBook()),
             new UserPrefs());
 
-        showPersonAtIndex(model, INDEX_SECOND_PERSON);
-        Task taskToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         expectedModel.updatePerson(taskToEdit, editedTask);
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/model/attachment/AttachmentTest.java
+++ b/src/test/java/seedu/address/model/attachment/AttachmentTest.java
@@ -1,0 +1,31 @@
+package seedu.address.model.attachment;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import seedu.address.testutil.Assert;
+
+public class AttachmentTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new Attachment(null));
+    }
+
+
+    @Test
+    public void equality_relativeAndRelativeFilePath() {
+        File dummyFileRelativePath = new File("hello.txt");
+        File dummyFileAbsolutePath = new File(dummyFileRelativePath.getAbsolutePath());
+
+        Attachment relativeAttachment = new Attachment(dummyFileRelativePath);
+        Attachment absoluteAttachment = new Attachment(dummyFileAbsolutePath);
+
+        assertEquals(relativeAttachment, absoluteAttachment);
+    }
+
+
+}

--- a/src/test/java/seedu/address/storage/XmlAdaptedTaskTest.java
+++ b/src/test/java/seedu/address/storage/XmlAdaptedTaskTest.java
@@ -35,6 +35,10 @@ public class XmlAdaptedTaskTest {
     private static final List<XmlAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
         .map(XmlAdaptedTag::new)
         .collect(Collectors.toList());
+    private static final List<XmlAdaptedAttachment> VALID_ATTACHMENTS = BENSON.getAttachments()
+        .stream()
+        .map(XmlAdaptedAttachment::new)
+        .collect(Collectors.toList());
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -46,7 +50,7 @@ public class XmlAdaptedTaskTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         XmlAdaptedTask person =
             new XmlAdaptedTask(INVALID_NAME, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS);
+                VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = Name.MESSAGE_NAME_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -54,7 +58,7 @@ public class XmlAdaptedTaskTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         XmlAdaptedTask person = new XmlAdaptedTask(null, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS,
-            VALID_TAGS);
+            VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = String
             .format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -64,7 +68,7 @@ public class XmlAdaptedTaskTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         XmlAdaptedTask person =
             new XmlAdaptedTask(VALID_NAME, INVALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS);
+                VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = Phone.MESSAGE_PHONE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -72,7 +76,7 @@ public class XmlAdaptedTaskTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         XmlAdaptedTask person = new XmlAdaptedTask(VALID_NAME, null, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS,
-            VALID_TAGS);
+            VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = String
             .format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -82,7 +86,7 @@ public class XmlAdaptedTaskTest {
     public void toModelType_invalidPriority_throwsIllegalValueException() {
         XmlAdaptedTask person =
             new XmlAdaptedTask(VALID_NAME, VALID_PHONE, INVALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS);
+                VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = Priority.MESSAGE_PRIORITY_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -90,7 +94,7 @@ public class XmlAdaptedTaskTest {
     @Test
     public void toModelType_nullPriority_throwsIllegalValueException() {
         XmlAdaptedTask person = new XmlAdaptedTask(VALID_NAME, VALID_PHONE, null, VALID_EMAIL, VALID_ADDRESS,
-            VALID_TAGS);
+            VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = String
             .format(MISSING_FIELD_MESSAGE_FORMAT, Priority.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -100,7 +104,7 @@ public class XmlAdaptedTaskTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         XmlAdaptedTask person =
             new XmlAdaptedTask(VALID_NAME, VALID_PHONE, VALID_PRIORITY, INVALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS);
+                VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = Email.MESSAGE_EMAIL_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +112,7 @@ public class XmlAdaptedTaskTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         XmlAdaptedTask person = new XmlAdaptedTask(VALID_NAME, VALID_PHONE, VALID_PRIORITY, null, VALID_ADDRESS,
-            VALID_TAGS);
+            VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = String
             .format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -118,7 +122,7 @@ public class XmlAdaptedTaskTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         XmlAdaptedTask person =
             new XmlAdaptedTask(VALID_NAME, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, INVALID_ADDRESS,
-                VALID_TAGS);
+                VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = Address.MESSAGE_ADDRESS_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -126,7 +130,7 @@ public class XmlAdaptedTaskTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         XmlAdaptedTask person = new XmlAdaptedTask(VALID_NAME, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, null,
-            VALID_TAGS);
+            VALID_TAGS, VALID_ATTACHMENTS);
         String expectedMessage = String
             .format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -138,7 +142,7 @@ public class XmlAdaptedTaskTest {
         invalidTags.add(new XmlAdaptedTag(INVALID_TAG));
         XmlAdaptedTask person =
             new XmlAdaptedTask(VALID_NAME, VALID_PHONE, VALID_PRIORITY, VALID_EMAIL, VALID_ADDRESS,
-                invalidTags);
+                invalidTags, VALID_ATTACHMENTS);
         Assert.assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -40,7 +40,6 @@ public class EditPersonDescriptorBuilder {
         descriptor.setDeadline(task.getDeadline());
         descriptor.setAddress(task.getAddress());
         descriptor.setTags(task.getTags());
-        descriptor.setAttachments(task.getAttachments());
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -109,6 +109,24 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Parses the {@code attachments} into a {@code Set<Attachment>} and set it to the {@code Task} that we are
+     * building.
+     */
+    public PersonBuilder withAttachments(Set<Attachment> attachments) {
+        this.attachments = attachments;
+        return this;
+    }
+
+    /**
+     * Parses the {@code attachments} into a {@code Set<Attachment>} and set it to the {@code Task} that we are
+     * building.
+     */
+    public PersonBuilder withAttachments(String... attachments) {
+        this.attachments = SampleDataUtil.getAttachmentSet(attachments);
+        return this;
+    }
+
     public Task build() {
         return new Task(name, phone, priority, email, deadline, address, tags, attachments);
     }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -32,6 +32,7 @@ public class TypicalPersons {
         .withPhone("94351253")
         .withPriority("1")
         .withTags("friends")
+        .withAttachments("hello.txt", "world.txt")
         .build();
     public static final Task BENSON = new PersonBuilder()
         .withName("Benson Meier")
@@ -40,6 +41,7 @@ public class TypicalPersons {
         .withPhone("98765432")
         .withPriority("2")
         .withTags("owesMoney", "friends")
+        .withAttachments("hello.txt", "world.txt")
         .build();
     public static final Task CARL = new PersonBuilder()
         .withName("Carl Kurz")
@@ -47,6 +49,7 @@ public class TypicalPersons {
         .withPriority("3")
         .withEmail("heinz@example.com")
         .withAddress("wall street")
+        .withAttachments("world.txt")
         .build();
     public static final Task DANIEL = new PersonBuilder().withName("Daniel Meier")
         .withPhone("87652533")
@@ -55,28 +58,62 @@ public class TypicalPersons {
         .withAddress("10th street")
         .withTags("friends")
         .build();
-    public static final Task ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224").withPriority("1")
-        .withEmail("werner@example.com").withAddress("michegan ave").build();
-    public static final Task FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427").withPriority("2")
-        .withEmail("lydia@example.com").withAddress("little tokyo").build();
-    public static final Task GEORGE = new PersonBuilder().withName("George Best")
-        .withPhone("9482442").withPriority("3")
-        .withEmail("anna@example.com").withAddress("4th street").build();
+    public static final Task ELLE = new PersonBuilder()
+        .withName("Elle Meyer")
+        .withPhone("9482224")
+        .withPriority("1")
+        .withEmail("werner@example.com")
+        .withAddress("michegan ave")
+        .build();
+    public static final Task FIONA = new PersonBuilder()
+        .withName("Fiona Kunz")
+        .withPhone("9482427")
+        .withPriority("2")
+        .withEmail("lydia@example.com")
+        .withAddress("little tokyo")
+        .withAttachments("hello.txt", "world.txt")
+        .build();
+    public static final Task GEORGE = new PersonBuilder()
+        .withName("George Best")
+        .withPhone("9482442")
+        .withPriority("3")
+        .withEmail("anna@example.com")
+        .withAddress("4th street")
+        .withAttachments("hello.txt")
+        .build();
 
     // Manually added
-    public static final Task HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424").withPriority("4")
-        .withEmail("stefan@example.com").withAddress("little india").build();
-    public static final Task IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131").withPriority("1")
-        .withEmail("hans@example.com").withAddress("chicago ave").build();
+    public static final Task HOON = new PersonBuilder()
+        .withName("Hoon Meier")
+        .withPhone("8482424")
+        .withPriority("4")
+        .withEmail("stefan@example.com")
+        .withAddress("little india")
+        .withAttachments("world.txt")
+        .build();
+    public static final Task IDA = new PersonBuilder()
+        .withName("Ida Mueller")
+        .withPhone("8482131")
+        .withPriority("1")
+        .withEmail("hans@example.com")
+        .withAddress("chicago ave")
+        .build();
 
     // Manually added - Task's details found in {@code CommandTestUtil}
-    public static final Task AMY = new PersonBuilder().withName(VALID_NAME_AMY)
-        .withPhone(VALID_PHONE_AMY).withPriority(VALID_PRIORITY_AMY)
-        .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
+    public static final Task AMY = new PersonBuilder()
+        .withName(VALID_NAME_AMY)
+        .withPhone(VALID_PHONE_AMY)
+        .withPriority(VALID_PRIORITY_AMY)
+        .withEmail(VALID_EMAIL_AMY)
+        .withAddress(VALID_ADDRESS_AMY)
+        .withTags(VALID_TAG_FRIEND)
         .build();
-    public static final Task BOB = new PersonBuilder().withName(VALID_NAME_BOB)
-        .withPhone(VALID_PHONE_BOB).withPriority(VALID_PRIORITY_BOB)
-        .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+    public static final Task BOB = new PersonBuilder()
+        .withName(VALID_NAME_BOB)
+        .withPhone(VALID_PHONE_BOB)
+        .withPriority(VALID_PRIORITY_BOB)
+        .withEmail(VALID_EMAIL_BOB)
+        .withAddress(VALID_ADDRESS_BOB)
         .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
         .build();
 

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -229,7 +229,10 @@ public class AddCommandSystemTest extends TaskCollectionSystemTest {
      * @see TaskCollectionSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandSuccess(Task toAdd) {
-        assertCommandSuccess(PersonUtil.getAddCommand(toAdd), toAdd);
+        Task toAddWithoutAttachment = new PersonBuilder(toAdd)
+            .withAttachments()
+            .build();
+        assertCommandSuccess(PersonUtil.getAddCommand(toAddWithoutAttachment), toAddWithoutAttachment);
     }
 
     /**
@@ -240,8 +243,11 @@ public class AddCommandSystemTest extends TaskCollectionSystemTest {
      */
     private void assertCommandSuccess(String command, Task toAdd) {
         Model expectedModel = getModel();
-        expectedModel.addPerson(toAdd);
-        String expectedResultMessage = String.format(AddCommand.MESSAGE_SUCCESS, toAdd);
+        Task toAddWithoutAttachments = new PersonBuilder(toAdd)
+            .withAttachments()
+            .build();
+        expectedModel.addPerson(toAddWithoutAttachments);
+        String expectedResultMessage = String.format(AddCommand.MESSAGE_SUCCESS, toAddWithoutAttachments);
 
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
     }

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -68,7 +68,13 @@ public class EditCommandSystemTest extends TaskCollectionSystemTest {
                 + "  "
                 + PHONE_DESC_BOB + " " + PRIORITY_DESC_BOB + " " + EMAIL_DESC_BOB + "  " + ADDRESS_DESC_BOB + " "
                 + TAG_DESC_HUSBAND + " ";
-        Task editedTask = new PersonBuilder(BOB).withTags(VALID_TAG_HUSBAND).build();
+        Task uneditedTask = getModel().getFilteredPersonList().get(index.getZeroBased());
+        Task bobWithOriginalAttachments = new PersonBuilder(BOB)
+            .withAttachments(uneditedTask.getAttachments())
+            .build();
+        Task editedTask = new PersonBuilder(bobWithOriginalAttachments)
+            .withTags(VALID_TAG_HUSBAND)
+            .build();
         assertCommandSuccess(command, index, editedTask);
 
         /* Case: undo editing the last task in the list -> last task restored */
@@ -88,16 +94,16 @@ public class EditCommandSystemTest extends TaskCollectionSystemTest {
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB
             + PHONE_DESC_BOB + PRIORITY_DESC_BOB + EMAIL_DESC_BOB
             + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        assertCommandSuccess(command, index, BOB);
+        assertCommandSuccess(command, index, bobWithOriginalAttachments);
 
         /* Case: edit a task with new values same as another task's values but with different name -> edited */
-        assertTrue(getModel().getAddressBook().getTaskList().contains(BOB));
+        assertTrue(getModel().getAddressBook().getTaskList().contains(bobWithOriginalAttachments));
         index = INDEX_SECOND_PERSON;
-        assertNotEquals(getModel().getFilteredPersonList().get(index.getZeroBased()), BOB);
+        assertNotEquals(getModel().getFilteredPersonList().get(index.getZeroBased()), editedTask);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY
             + PHONE_DESC_BOB + PRIORITY_DESC_BOB + EMAIL_DESC_BOB
             + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        editedTask = new PersonBuilder(BOB).withName(VALID_NAME_AMY).build();
+        editedTask = new PersonBuilder(bobWithOriginalAttachments).withName(VALID_NAME_AMY).build();
         assertCommandSuccess(command, index, editedTask);
 
         /* Case: edit a task with new values same as another task's values but with different phone and email
@@ -108,7 +114,7 @@ public class EditCommandSystemTest extends TaskCollectionSystemTest {
             + PHONE_DESC_AMY + PRIORITY_DESC_AMY + EMAIL_DESC_AMY
             + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
         editedTask =
-            new PersonBuilder(BOB).withPriority(VALID_PRIORITY_AMY).withPhone(VALID_PHONE_AMY)
+            new PersonBuilder(bobWithOriginalAttachments).withPriority(VALID_PRIORITY_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).build();
         assertCommandSuccess(command, index, editedTask);
 
@@ -152,7 +158,10 @@ public class EditCommandSystemTest extends TaskCollectionSystemTest {
             + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
         // this can be misleading: card selection actually remains unchanged but the
         // browser's url is updated to reflect the new task's name
-        assertCommandSuccess(command, index, AMY, index);
+        Task amyWithAttachments = new PersonBuilder(AMY)
+            .withAttachments(getModel().getFilteredPersonList().get(index.getZeroBased()).getAttachments())
+            .build();
+        assertCommandSuccess(command, index, amyWithAttachments, index);
 
         /* --------------------------------- Performing invalid edit operation -------------------------------------- */
 


### PR DESCRIPTION
Storage
- Added XML attribute "attachments" to store a list of attachments for each task.
- Export and re-import tested.
- Storage tests are heavily modified to add the new attribute.

Attachment
- Updated to compare equal based on absolute directory.
- Currently does not support import/export.
- Only supports saving/reading from file so that it persists between application restarts.

EditCommand is not supposed to update attachments. 
Tests for EditCommand is updated so that it does not fail in the following scenarios:
- Tests are edited to be aware of attachments and make sure that attachments remain unmodified.
- When editing a task, the expectedTask after the modification includes the attachments of the originalTask. This indirectly allows us to check that attachments remain unmodified.

Tests for AddCommand is updated so that it does not fail in the following scenarios:
- Attempts to add ("clone") an existing task by adding it to the Deadline Manager. However, the task will fail to compare equal to the existing task if the existing task has attachments. This has been fixed by checking a copy of the existing task without attachments.