### PR TITLE
Add comparable to priority (with tests)

### DIFF
--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Task's priority in the deadline manager. Guarantees: immutable; is valid as declared
  * in {@link #isValidPriority(String)}
  */
-public class Priority {
+public class Priority implements Comparable<Priority> {
 
 
     public static final String MESSAGE_PRIORITY_CONSTRAINTS =
@@ -50,4 +50,8 @@ public class Priority {
         return value.hashCode();
     }
 
+    @Override
+    public int compareTo(Priority other) {
+        return this.value.compareTo(other.value);
+    }
 }

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -26,6 +26,10 @@ public class Priority implements Comparable<Priority> {
         value = priority;
     }
 
+    public Priority(Integer priority) {
+        this(String.format("%d", priority));
+    }
+
     /**
      * Returns true if a given string is a valid priority number.
      */

--- a/src/test/java/seedu/address/model/task/PriorityTest.java
+++ b/src/test/java/seedu/address/model/task/PriorityTest.java
@@ -11,13 +11,15 @@ public class PriorityTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> new Priority(null));
+        Assert.assertThrows(NullPointerException.class, () -> new Priority((String) null));
     }
 
     @Test
     public void constructor_invalidPriority_throwsIllegalArgumentException() {
         String invalidPriority = "";
+        Integer invalidPriorityInteger = -1;
         Assert.assertThrows(IllegalArgumentException.class, () -> new Priority(invalidPriority));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Priority(invalidPriorityInteger));
     }
 
     @Test
@@ -41,7 +43,7 @@ public class PriorityTest {
     public void isValidComparison() {
         Priority a = new Priority("3");
         Priority b = new Priority("4");
-        Priority c = new Priority("3");
+        Priority c = new Priority(3);
         assertTrue(a.compareTo(b) == -1);
         assertTrue(b.compareTo(a) == 1);
         assertTrue(a.compareTo(c) == 0);

--- a/src/test/java/seedu/address/model/task/PriorityTest.java
+++ b/src/test/java/seedu/address/model/task/PriorityTest.java
@@ -36,4 +36,14 @@ public class PriorityTest {
         assertTrue(Priority.isValidPriority("3")); // 1, 2, 3, or 4
         assertTrue(Priority.isValidPriority("4"));
     }
+
+    @Test
+    public void isValidComparison() {
+        Priority a = new Priority("3");
+        Priority b = new Priority("4");
+        Priority c = new Priority("3");
+        assertTrue(a.compareTo(b) == -1);
+        assertTrue(b.compareTo(a) == 1);
+        assertTrue(a.compareTo(c) == 0);
+    }
 }


### PR DESCRIPTION
Fixes #80 

- Adding a comparable resolves the issue since now Priority will be able to support sorting and filtering based on conditions. 
- Also added a constructor which takes in an integer for Priority so that filtering on Priorities is easier to implement.

@btzy For filtering with priority - (Example - "filter p>3"), you should consider first making a new priority by calling new Priority(3) or new Priority("3")