### PR TITLE
Import Export: Refactor and add more tests

### DIFF
--- a/src/main/java/seedu/address/commons/events/model/ExportRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/ExportRequestEvent.java
@@ -1,0 +1,23 @@
+package seedu.address.commons.events.model;
+
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.model.ReadOnlyTaskCollection;
+
+/**
+ * Indicates a request to export the current taskcollection view.
+ */
+public class ExportRequestEvent extends BaseEvent {
+
+    public final ReadOnlyTaskCollection data;
+    public final String filename;
+
+    public ExportRequestEvent(ReadOnlyTaskCollection data, String filename) {
+        this.data = data;
+        this.filename = filename;
+    }
+
+    @Override
+    public String toString() {
+        return "number of persons " + data.getTaskList().size();
+    }
+}

--- a/src/main/java/seedu/address/commons/events/model/ImportRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/ImportRequestEvent.java
@@ -1,0 +1,20 @@
+package seedu.address.commons.events.model;
+
+import seedu.address.commons.events.BaseEvent;
+
+/**
+ * Indicates a request to import to the current model.
+ */
+public class ImportRequestEvent extends BaseEvent {
+
+    public final String filename;
+
+    public ImportRequestEvent(String filename) {
+        this.filename = filename;
+    }
+
+    @Override
+    public String toString() {
+        return "importing from " + filename;
+    }
+}

--- a/src/main/java/seedu/address/commons/events/storage/ImportDataAvailableEvent.java
+++ b/src/main/java/seedu/address/commons/events/storage/ImportDataAvailableEvent.java
@@ -1,0 +1,22 @@
+package seedu.address.commons.events.storage;
+
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.model.ReadOnlyTaskCollection;
+
+/**
+ * Indicates that a new result is available.
+ */
+public class ImportDataAvailableEvent extends BaseEvent {
+
+    public final ReadOnlyTaskCollection data;
+
+    public ImportDataAvailableEvent(ReadOnlyTaskCollection data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/src/main/java/seedu/address/commons/events/storage/ImportExportExceptionEvent.java
+++ b/src/main/java/seedu/address/commons/events/storage/ImportExportExceptionEvent.java
@@ -1,0 +1,21 @@
+package seedu.address.commons.events.storage;
+
+import seedu.address.commons.events.BaseEvent;
+
+/**
+ * Indicates an exception during a file saving
+ */
+public class ImportExportExceptionEvent extends BaseEvent {
+
+    public final Exception exception;
+
+    public ImportExportExceptionEvent(Exception exception) {
+        this.exception = exception;
+    }
+
+    @Override
+    public String toString() {
+        return exception.toString();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -2,17 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.TaskCollection;
-import seedu.address.model.task.Task;
-import seedu.address.storage.Storage;
 
 /**
  * Imports all tasks from an external deadline manager export file.
@@ -21,24 +13,23 @@ public class ExportCommand extends Command {
 
     public static final String COMMAND_WORD = "export";
     public static final String MESSAGE_EXPORT_ERROR = "Export failed. Error: %s";
-    public static final String MESSAGE_SUCCESS = "Exported successfully to external file.";
+    public static final String MESSAGE_SUCCESS = "Exported successfully to external file: %s";
     public static final String MESSAGE_USAGE = "export filename";
-    private Path pathName;
+    private String pathName;
     public ExportCommand(String filename) {
-        this.pathName = Paths.get(filename);
+        this.pathName = filename;
+        //this.pathName = Paths.get(filename);
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        List<Task> lastShownList = model.getFilteredPersonList();
-        TaskCollection exportCollection = new TaskCollection();
-        exportCollection.setTasks(lastShownList);
-        try {
-            Storage.exportTaskCollection(exportCollection, pathName);
-        } catch (IOException e) {
-            throw new CommandException(String.format(MESSAGE_EXPORT_ERROR, e.getMessage()));
+        model.exportAddressBook(pathName);
+        if (model.importExportFailed()) {
+            String errorMessage = model.getLastError();
+            throw new CommandException(String.format(MESSAGE_EXPORT_ERROR, errorMessage));
+        } else {
+            return new CommandResult(String.format(MESSAGE_SUCCESS, pathName));
         }
-        return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
 
 /**
  * Imports all tasks from an external deadline manager export file.

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,10 +1,12 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.ModelManager.ImportConflictMode;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
 
 /**
  * Imports all tasks from an external deadline manager export file.
@@ -16,14 +18,20 @@ public class ImportCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Imported successfully from file: %s";
     public static final String MESSAGE_USAGE = "import filename";
     private String fileName;
+    private ImportConflictMode conflictResolver;
+
     public ImportCommand(String fileName) {
+        this(fileName, ImportConflictMode.IGNORE);
+    }
+    public ImportCommand(String fileName, ImportConflictMode conflictResolver) {
         this.fileName = fileName;
+        this.conflictResolver = conflictResolver;
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        model.importAddressBook(fileName);
+        model.importAddressBook(fileName, conflictResolver);
         if (model.importExportFailed()) {
             String errorMessage = model.getLastError();
             throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, errorMessage));

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -2,17 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyTaskCollection;
-import seedu.address.model.task.Task;
-import seedu.address.storage.Storage;
 
 /**
  * Imports all tasks from an external deadline manager export file.
@@ -23,23 +15,21 @@ public class ImportCommand extends Command {
     public static final String MESSAGE_IMPORT_ERROR = "Import failed. Error: %s";
     public static final String MESSAGE_SUCCESS = "Imported successfully from external file.";
     public static final String MESSAGE_USAGE = "import filename";
-    private Path pathName;
-    public ImportCommand(String filename) {
-        this.pathName = Paths.get(filename);
+    private String fileName;
+    public ImportCommand(String fileName) {
+        this.fileName = fileName;
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        try {
-            ReadOnlyTaskCollection importedCollection = Storage.importTaskCollection(pathName).get();
-            for (Task task: importedCollection.getTaskList()) {
-                model.addPerson(task);
-            }
-        } catch (DataConversionException | IOException e) {
-            throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, e));
+        model.importAddressBook(fileName);
+        if (model.importExportFailed()) {
+            String errorMessage = model.getLastError();
+            return new CommandResult(String.format(MESSAGE_IMPORT_ERROR, errorMessage));
+        } else {
+            //model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(MESSAGE_SUCCESS);
         }
-        //model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -13,7 +13,7 @@ public class ImportCommand extends Command {
 
     public static final String COMMAND_WORD = "import";
     public static final String MESSAGE_IMPORT_ERROR = "Import failed. Error: %s";
-    public static final String MESSAGE_SUCCESS = "Imported successfully from external file.";
+    public static final String MESSAGE_SUCCESS = "Imported successfully from file: %s";
     public static final String MESSAGE_USAGE = "import filename";
     private String fileName;
     public ImportCommand(String fileName) {
@@ -26,10 +26,10 @@ public class ImportCommand extends Command {
         model.importAddressBook(fileName);
         if (model.importExportFailed()) {
             String errorMessage = model.getLastError();
-            return new CommandResult(String.format(MESSAGE_IMPORT_ERROR, errorMessage));
+            throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, errorMessage));
         } else {
             //model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(MESSAGE_SUCCESS);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, fileName));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,14 +1,19 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.model.ModelManager.ImportConflictMode;
 
 import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelManager;
 
 /**
  * Parses input arguments and creates a new ImportCommand object
  */
 public class ImportCommandParser implements Parser<ImportCommand> {
+
+    public static final String FILENAME_CONSTRAINT = "Invalid filename! File name can only contain alphanumeric"
+        + " characters, full stop and the underscore [_] characters";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ImportCommand and returns an
@@ -17,13 +22,38 @@ public class ImportCommandParser implements Parser<ImportCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public ImportCommand parse(String args) throws ParseException {
-        String filename = args.trim();
-        if (filename.isEmpty()) {
+        String[] input = args.trim().split("\\s+");
+        if (input.length == 0) {
             throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
         }
+        String filename = input[0].trim();
+        if (!validFileName(filename)) {
+            throw new ParseException(FILENAME_CONSTRAINT);
+        }
+        if (input.length == 1) {
+            return new ImportCommand(filename);
+        }
+        else {
+            String option = input[1].trim();
+            switch (option) {
+            case "/all":
+                return new ImportCommand(filename, ImportConflictMode.DUPLICATE);
+            case "/overwrite":
+                return new ImportCommand(filename, ImportConflictMode.OVERWRITE);
+            case "/skip":
+                return new ImportCommand(filename, ImportConflictMode.IGNORE);
+            default:
+                throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+            }
+        }
 
-        return new ImportCommand(filename);
+
+    }
+
+    private boolean validFileName(String filename) {
+        return filename.matches("^[a-zA-Z0-9_.]+$");
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.model.ModelManager.ImportConflictMode;
 
 import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.ModelManager;
 
 /**
  * Parses input arguments and creates a new ImportCommand object
@@ -33,8 +32,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
         }
         if (input.length == 1) {
             return new ImportCommand(filename);
-        }
-        else {
+        } else {
             String option = input[1].trim();
             switch (option) {
             case "/all":

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,7 +3,11 @@ package seedu.address.model;
 import java.util.Comparator;
 import java.util.function.Predicate;
 
+import com.google.common.eventbus.Subscribe;
+
 import javafx.collections.ObservableList;
+import seedu.address.commons.events.storage.ImportDataAvailableEvent;
+import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.model.task.Task;
 
 /**
@@ -91,4 +95,28 @@ public interface Model {
      * Saves the current deadline manager state for undo/redo.
      */
     void commitAddressBook();
+
+    boolean importExportFailed();
+
+    String getLastError();
+
+    /**
+     * Exports current deadline manager to file.
+     */
+    void exportAddressBook(String filename);
+
+    /**
+     * Imports tasks from file to the current deadline manager.
+     */
+    void importAddressBook(String filename);
+
+    /**
+     * Handler for the return result from Storage, when import data has been read.
+     * @param event the import data event
+     */
+    @Subscribe
+    void handleImportDataAvailableEvent(ImportDataAvailableEvent event);
+
+    @Subscribe
+    void handleImportExportExceptionEvent(ImportExportExceptionEvent event);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -111,6 +111,11 @@ public interface Model {
     void importAddressBook(String filename);
 
     /**
+     * Imports tasks from file to the current deadline manager.
+     */
+    void importAddressBook(String filename, ModelManager.ImportConflictMode mode);
+
+    /**
      * Handler for the return result from Storage, when import data has been read.
      * @param event the import data event
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -28,6 +28,9 @@ import seedu.address.model.task.Task;
  */
 public class ModelManager extends ComponentManager implements Model {
 
+    /**
+     * An enum representing the possible conflict resolvers.
+     */
     public enum ImportConflictMode {
         OVERWRITE, DUPLICATE, IGNORE
     };
@@ -221,6 +224,11 @@ public class ModelManager extends ComponentManager implements Model {
         lastError = event.toString();
     }
 
+    /**
+     * Use the appropriate import conflict handler to resolve a conflict.
+     * If there is no conflict, simply add it to the current TaskCollection.
+     * @param task the task to deconflict
+     */
     private void resolveImportConflict(Task task) {
         if (!hasPerson(task)) {
             addPerson(task);

--- a/src/main/java/seedu/address/storage/ImportExportStorage.java
+++ b/src/main/java/seedu/address/storage/ImportExportStorage.java
@@ -1,0 +1,40 @@
+package seedu.address.storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.model.ReadOnlyTaskCollection;
+import seedu.address.model.TaskCollection;
+
+/**
+ * Represents a storage for {@link TaskCollection}.
+ */
+public interface ImportExportStorage {
+
+    /**
+     * Returns the file path of the data file.
+     */
+    Path getTaskCollectionFilePath();
+
+    /**
+     * Returns TaskCollection data as a {@link ReadOnlyTaskCollection}. Returns {@code Optional.empty()}
+     * if import file is not found.
+     *
+     * @param filePath location of import file.
+     * @throws DataConversionException if the data in storage is not in the expected format.
+     * @throws IOException             if there was any problem when reading from the storage.
+     */
+    Optional<ReadOnlyTaskCollection> importTaskCollection(Path filePath) throws DataConversionException, IOException;
+
+    /**
+     * Saves the given {@link ReadOnlyTaskCollection} to the path specified.
+     *
+     * @param taskCollection cannot be null.
+     * @param filePath location of export file.
+     * @throws IOException if there was any problem writing to the file.
+     */
+    void exportTaskCollection(ReadOnlyTaskCollection taskCollection, Path filePath) throws IOException;
+
+}

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -1,12 +1,11 @@
 package seedu.address.storage;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.logging.Logger;
 
-import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.model.ExportRequestEvent;
+import seedu.address.commons.events.model.ImportRequestEvent;
 import seedu.address.commons.events.model.TaskCollectionChangedEvent;
 import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 import seedu.address.commons.exceptions.DataConversionException;
@@ -16,7 +15,7 @@ import seedu.address.model.UserPrefs;
 /**
  * API of the Storage component
  */
-public interface Storage extends TaskCollectionStorage, UserPrefsStorage {
+public interface Storage extends ImportExportStorage, TaskCollectionStorage, UserPrefsStorage {
 
     String MESSAGE_WRITE_FILE_EXISTS_ERROR = "Save file already exists."
             + " Please rename to avoid losing data.";
@@ -46,16 +45,9 @@ public interface Storage extends TaskCollectionStorage, UserPrefsStorage {
      * @throws DataConversionException
      * @throws IOException
      */
-    static Optional<ReadOnlyTaskCollection> importTaskCollection(Path filePath)
-            throws DataConversionException, IOException {
-        Logger logger = LogsCenter.getLogger(StorageManager.class);
-        if (!fileExists(filePath)) {
-            throw new IOException(MESSAGE_READ_FILE_MISSING_ERROR);
-        }
-        TaskCollectionStorage importExportStorage = new XmlTaskCollectionStorage(filePath);
-        logger.fine("Attempting to import from file: " + filePath);
-        return importExportStorage.readTaskCollection(filePath);
-    }
+    @Override
+    Optional<ReadOnlyTaskCollection> importTaskCollection(Path filePath)
+            throws DataConversionException, IOException;
 
     /**
      * Exports the current view of task collection to a path specified. The path must not already exist,
@@ -64,30 +56,19 @@ public interface Storage extends TaskCollectionStorage, UserPrefsStorage {
      * @param filePath The file to export to
      * @throws IOException
      */
-    static void exportTaskCollection(ReadOnlyTaskCollection taskCollection, Path filePath) throws IOException {
-        Logger logger = LogsCenter.getLogger(StorageManager.class);
-        if (fileExists(filePath)) {
-            throw new IOException(MESSAGE_WRITE_FILE_EXISTS_ERROR);
-        }
-        TaskCollectionStorage importExportStorage = new XmlTaskCollectionStorage(filePath);
-        logger.fine("Attempting to export to file: " + filePath);
-        importExportStorage.saveTaskCollection(taskCollection);
-    }
+    @Override
+    void exportTaskCollection(ReadOnlyTaskCollection taskCollection, Path filePath) throws IOException;
 
-    /**
-     * Helper function to determine whether file exists.
-     * @param filePath File to be inspected
-     * @return true if file exists, false otherwise
-     */
-    private static boolean fileExists(Path filePath) {
-        File file = new File(filePath.toString());
-        return file.exists() && file.isFile();
-    }
 
     /**
      * Saves the current version of the deadline manager to the hard disk. Creates the data file if it
      * is missing. Raises {@link DataSavingExceptionEvent} if there was an error during saving.
      */
     void handleTaskCollectionChangedEvent(TaskCollectionChangedEvent abce);
+
+    void handleExportRequestEvent(ExportRequestEvent ere);
+
+    void handleImportRequestEvent(ImportRequestEvent ire);
+
 }
 

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -21,6 +21,7 @@ public interface Storage extends ImportExportStorage, TaskCollectionStorage, Use
             + " Please rename to avoid losing data.";
     String MESSAGE_READ_FILE_MISSING_ERROR = "File does not exist."
             + " Double check your import file.";
+    String MESSAGE_READ_FILE_SAME_ERROR = "Cannot import from the current working file.";
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -7,17 +7,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
-import java.util.function.Predicate;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyTaskCollection;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.task.Task;
@@ -86,81 +82,7 @@ public class AddCommandTest {
         assertFalse(addAliceCommand.equals(addBobCommand));
     }
 
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
 
-        @Override
-        public void addPerson(Task task) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void resetData(ReadOnlyTaskCollection newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyTaskCollection getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Task task) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Task target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updatePerson(Task target, Task editedTask) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateSortedPersonList(Comparator<Task> comparator) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Task> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Task> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean canUndoAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean canRedoAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void undoAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void redoAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void commitAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
 
     /**
      * A Model stub that contains a single task.
@@ -209,6 +131,7 @@ public class AddCommandTest {
         public ReadOnlyTaskCollection getAddressBook() {
             return new TaskCollection();
         }
+
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,23 +1,18 @@
 package seedu.address.logic.commands;
 
-import static org.junit.Assert.assertNotNull;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
+import seedu.address.model.TaskCollection;
+import seedu.address.model.task.Task;
+import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
 
 /**
@@ -26,54 +21,55 @@ import seedu.address.storage.StorageManager;
 public class ExportCommandTest {
 
     public final String temporaryFilePath = "dummySaveFile";
-    private Model model;
-    private Model expectedModel;
     private CommandHistory commandHistory = new CommandHistory();
-    private Path defaultPath = Paths.get("fakeDefaultPath");
-    private boolean shouldDeleteDefaultPath = false;
-
-    @Before
-    public void setUp() throws IOException {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        if (Files.notExists(defaultPath)) {
-            Files.createFile(defaultPath);
-            shouldDeleteDefaultPath = true;
-        }
-    }
+    private String defaultFile = "fakeDefaultPath";
+    private ModelStubWithExportAddressBook modelStub = new ModelStubWithExportAddressBook(defaultFile);
 
     @Test
     public void execute_exportOnWorkingFile_exceptionThrown() {
-        assertCommandFailure(new ExportCommand(defaultPath.toString()), model, commandHistory,
-                String.format(ExportCommand.MESSAGE_EXPORT_ERROR, StorageManager.MESSAGE_WRITE_FILE_EXISTS_ERROR));
+        IOException expectedException = new IOException(StorageManager.MESSAGE_WRITE_FILE_EXISTS_ERROR);
+        assertCommandFailure(new ExportCommand(defaultFile), modelStub, commandHistory,
+                String.format(ExportCommand.MESSAGE_EXPORT_ERROR, expectedException.toString()));
     }
 
     @Test
     public void execute_exportNewFile_exportSuccessful() {
-        assertCommandSuccess(new ExportCommand(temporaryFilePath), model,
-                commandHistory, ExportCommand.MESSAGE_SUCCESS, model);
-        Path exportPath = Paths.get(temporaryFilePath);
-        assertDataCorrect(exportPath);
+        assertCommandSuccess(new ExportCommand(temporaryFilePath), modelStub,
+                commandHistory, String.format(ExportCommand.MESSAGE_SUCCESS, temporaryFilePath), modelStub);
     }
 
-    /**
-     * Checks that a file was correctly written.
-     * @param exportPath the file to check
-     */
-    private void assertDataCorrect(Path exportPath) {
-        try {
-            byte[] b2 = Files.readAllBytes(exportPath);
-            assertNotNull(b2);
-        } catch (IOException ioe) {
-            throw new AssertionError("Export files not found", ioe);
+    private class ModelStubWithExportAddressBook extends ModelStub {
+        private String filename = "";
+        private String lastError = null;
+        public ModelStubWithExportAddressBook(String defaultFile) {
+            filename = defaultFile;
         }
-    }
 
-    @After
-    public void tearDown() throws IOException {
-        if (shouldDeleteDefaultPath) {
-            Files.deleteIfExists(defaultPath);
+        @Override
+        public TaskCollection getAddressBook() {
+            return new TaskCollection();
         }
-        Files.deleteIfExists(Paths.get(temporaryFilePath));
+
+        @Override
+        public ObservableList<Task> getFilteredPersonList() {
+            return FXCollections.unmodifiableObservableList(new TaskCollection().getTaskList());
+        }
+
+        @Override
+        public void exportAddressBook(String filename) {
+            if (filename == this.filename) {
+                lastError = new IOException(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR).toString();
+            }
+        }
+
+        @Override
+        public boolean importExportFailed() {
+            return lastError != null;
+        }
+
+        @Override
+        public String getLastError() {
+            return lastError;
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.ModelManager;
 import seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.task.Task;

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ModelManager;
+import seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.task.Task;
 import seedu.address.storage.Storage;
@@ -58,6 +60,11 @@ public class ImportCommandTest {
 
         @Override
         public void importAddressBook(String filename) {
+            importAddressBook(filename, ImportConflictMode.IGNORE);
+        }
+
+        @Override
+        public void importAddressBook(String filename, ImportConflictMode conflictMode) {
             if (filename.equals(temporaryFilePath)) {
                 //No error.
                 return;

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -18,30 +18,31 @@ import seedu.address.storage.StorageManager;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
  */
-public class ExportCommandTest {
+public class ImportCommandTest {
 
     public final String temporaryFilePath = "dummySaveFile";
+    public final String doesNotExistPath = "doesNotExist";
     private CommandHistory commandHistory = new CommandHistory();
     private String defaultFile = "fakeDefaultPath";
-    private ModelStubWithExportAddressBook modelStub = new ModelStubWithExportAddressBook(defaultFile);
+    private ModelStubWithImportAddressBook modelStub = new ModelStubWithImportAddressBook(defaultFile);
 
     @Test
-    public void execute_exportOnWorkingFile_exceptionThrown() {
-        IOException expectedException = new IOException(StorageManager.MESSAGE_WRITE_FILE_EXISTS_ERROR);
-        assertCommandFailure(new ExportCommand(defaultFile), modelStub, commandHistory,
-                String.format(ExportCommand.MESSAGE_EXPORT_ERROR, expectedException.toString()));
+    public void execute_importMissingFile_exceptionThrown() {
+        IOException expectedException = new IOException(StorageManager.MESSAGE_READ_FILE_MISSING_ERROR);
+        assertCommandFailure(new ImportCommand(doesNotExistPath), modelStub, commandHistory,
+                String.format(ImportCommand.MESSAGE_IMPORT_ERROR, expectedException.toString()));
     }
 
     @Test
-    public void execute_exportNewFile_exportSuccessful() {
-        assertCommandSuccess(new ExportCommand(temporaryFilePath), modelStub,
-                commandHistory, String.format(ExportCommand.MESSAGE_SUCCESS, temporaryFilePath), modelStub);
+    public void execute_importExistingFile_importSuccessful() {
+        assertCommandSuccess(new ImportCommand(temporaryFilePath), modelStub,
+                commandHistory, String.format(ImportCommand.MESSAGE_SUCCESS, temporaryFilePath), modelStub);
     }
 
-    private class ModelStubWithExportAddressBook extends ModelStub {
+    private class ModelStubWithImportAddressBook extends ModelStub {
         private String filename = "";
         private String lastError = null;
-        public ModelStubWithExportAddressBook(String defaultFile) {
+        public ModelStubWithImportAddressBook(String defaultFile) {
             filename = defaultFile;
         }
 
@@ -56,10 +57,21 @@ public class ExportCommandTest {
         }
 
         @Override
-        public void exportAddressBook(String filename) {
-            if (filename.equals(this.filename)) {
-                lastError = new IOException(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR).toString();
+        public void importAddressBook(String filename) {
+            if (filename.equals(temporaryFilePath)) {
+                //No error.
+                return;
             }
+            if (filename.equals(this.filename)) {
+                lastError = new IOException(Storage.MESSAGE_READ_FILE_SAME_ERROR).toString();
+                return;
+            }
+            if (filename.equals(doesNotExistPath)) {
+                lastError = new IOException(Storage.MESSAGE_READ_FILE_MISSING_ERROR).toString();
+                return;
+            }
+            lastError = new AssertionError("Should not use this filename").toString();
+
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -1,0 +1,117 @@
+package seedu.address.logic.commands;
+
+import java.util.Comparator;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.events.storage.ImportDataAvailableEvent;
+import seedu.address.commons.events.storage.ImportExportExceptionEvent;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyTaskCollection;
+import seedu.address.model.task.Task;
+
+/**
+ * A default model stub that have all of the methods failing.
+ */
+public class ModelStub implements Model {
+
+    @Override
+    public void addPerson(Task task) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void resetData(ReadOnlyTaskCollection newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyTaskCollection getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPerson(Task task) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deletePerson(Task target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updatePerson(Task target, Task editedTask) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateSortedPersonList(Comparator<Task> comparator) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Task> getFilteredPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredPersonList(Predicate<Task> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean canUndoAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean canRedoAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void undoAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void redoAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void commitAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean importExportFailed() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public String getLastError() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void exportAddressBook(String filename) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void importAddressBook(String filename) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void handleImportDataAvailableEvent(ImportDataAvailableEvent event) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void handleImportExportExceptionEvent(ImportExportExceptionEvent event) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -7,7 +7,6 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.events.storage.ImportDataAvailableEvent;
 import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
 import seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.model.ReadOnlyTaskCollection;
 import seedu.address.model.task.Task;

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -7,6 +7,8 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.events.storage.ImportDataAvailableEvent;
 import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.model.ReadOnlyTaskCollection;
 import seedu.address.model.task.Task;
 
@@ -102,6 +104,11 @@ public class ModelStub implements Model {
 
     @Override
     public void importAddressBook(String filename) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void importAddressBook(String filename, ImportConflictMode conflictMode) {
         throw new AssertionError("This method should not be called.");
     }
 


### PR DESCRIPTION
There are significant refactoring to import export storage. Notably, switched to an event-based implementation.

Add new flags for import. To-do: Write unit tests for command parsers.