### PR TITLE
Add support for filtering by priority

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -13,6 +13,7 @@ import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.FilterOperator;
 import seedu.address.model.task.Name;
+import seedu.address.model.task.Priority;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
@@ -96,6 +97,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             case "due": {
                 Predicate<Deadline> deadlinePredicate = Deadline.makeFilter(operator, testPhrase);
                 predicate = task -> deadlinePredicate.test(task.getDeadline());
+                break;
+            }
+            case "p": // fallthrough
+            case "priority": {
+                Predicate<Priority> priorityPredicate = Priority.makeFilter(operator, testPhrase);
+                predicate = task -> priorityPredicate.test(task.getPriority());
                 break;
             }
             case "t": // fallthrough

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
 import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -3,6 +3,7 @@ package seedu.address.model.task;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
 import seedu.address.model.task.exceptions.InvalidPredicateException;
@@ -20,6 +21,7 @@ public class Priority implements Comparable<Priority> {
         "Priority should only be 0, 1, 2, 3, or 4";
     public static final String PRIORITY_VALIDATION_REGEX = "[01234]";
     public static final String NO_PRIORITY = "0";
+    public static final int LARGEST_PRIORITY_VALUE = 4;
     public final int value;
 
     /**
@@ -34,7 +36,15 @@ public class Priority implements Comparable<Priority> {
     }
 
     public Priority(int priority) {
+        checkArgument(isValidPriority(priority), MESSAGE_PRIORITY_CONSTRAINTS);
         this.value = priority;
+    }
+
+    /**
+     * Returns true if a given string is a valid priority number.
+     */
+    public static boolean isValidPriority(int test) {
+        return test >= 0 && test <= LARGEST_PRIORITY_VALUE;
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -3,7 +3,6 @@ package seedu.address.model.task;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
 import seedu.address.model.task.exceptions.InvalidPredicateException;

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -3,6 +3,13 @@ package seedu.address.model.task;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.task.exceptions.InvalidPredicateException;
+import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
+import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
+
 /**
  * Represents a Task's priority in the deadline manager. Guarantees: immutable; is valid as declared
  * in {@link #isValidPriority(String)}
@@ -14,7 +21,7 @@ public class Priority implements Comparable<Priority> {
         "Priority should only be 0, 1, 2, 3, or 4";
     public static final String PRIORITY_VALIDATION_REGEX = "[01234]";
     public static final String NO_PRIORITY = "0";
-    public final String value;
+    public final int value;
 
     /**
      * Constructs a {@code Priority}.
@@ -24,11 +31,11 @@ public class Priority implements Comparable<Priority> {
     public Priority(String priority) {
         requireNonNull(priority);
         checkArgument(isValidPriority(priority), MESSAGE_PRIORITY_CONSTRAINTS);
-        value = priority;
+        this.value = priority.charAt(0) - '0';
     }
 
-    public Priority(Integer priority) {
-        this(String.format("%d", priority));
+    public Priority(int priority) {
+        this.value = priority;
     }
 
     /**
@@ -38,25 +45,56 @@ public class Priority implements Comparable<Priority> {
         return test.matches(PRIORITY_VALIDATION_REGEX);
     }
 
+    /**
+     * Constructs a predicate from the given operator and test phrase.
+     *
+     * @param operator   The operator for this predicate.
+     * @param testPhrase The test phrase for this predicate.
+     */
+    public static Predicate<Priority> makeFilter(FilterOperator operator, String testPhrase)
+        throws InvalidPredicateException {
+        Priority tmpPriority;
+        try {
+            tmpPriority = new Priority(testPhrase);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidPredicateTestPhraseException(e);
+        }
+        switch (operator) {
+        case EQUAL:
+            return priority -> priority.equals(tmpPriority);
+        case LESS:
+            return priority -> priority.compareTo(tmpPriority) <= 0;
+        case CONVENIENCE: // convenience operator, works the same as ">"
+        case GREATER:
+            return priority -> priority.compareTo(tmpPriority) >= 0;
+        default:
+            throw new InvalidPredicateOperatorException();
+        }
+    }
+
     @Override
     public String toString() {
-        return value;
+        return String.valueOf(value);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof Priority // instanceof handles nulls
-            && value.equals(((Priority) other).value)); // state check
+            && value == ((Priority) other).value); // state check
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Integer.hashCode(value);
     }
 
     @Override
     public int compareTo(Priority other) {
-        return this.value.compareTo(other.value);
+        int booleanCompareResult = Boolean.compare(this.value > 0, other.value > 0);
+        if (booleanCompareResult != 0) {
+            return booleanCompareResult;
+        }
+        return Integer.compare(other.value, this.value);
     }
 }

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -30,7 +30,7 @@ public class Priority implements Comparable<Priority> {
     public Priority(String priority) {
         requireNonNull(priority);
         checkArgument(isValidPriority(priority), MESSAGE_PRIORITY_CONSTRAINTS);
-        this.value = priority.charAt(0) - '0';
+        this.value = Integer.parseInt(priority);
     }
 
     public Priority(int priority) {

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -65,7 +65,7 @@ public class XmlAdaptedTask {
      */
     public XmlAdaptedTask(Task source) {
         name = source.getName().value;
-        priority = source.getPriority().value;
+        priority = source.getPriority().toString();
         deadline = source.getDeadline().toString();
         tagged = source.getTags().stream()
             .map(XmlAdaptedTag::new)

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -63,14 +63,14 @@ public class SortCommandTest {
     public void execute_priorityAscendingNameAscending_success() {
         SortCommand command = ensureParseSuccess("priority< n<");
         command.execute(model, null);
-        assertEquals(Arrays.asList(ALICE, ELLE, BENSON, FIONA, CARL, GEORGE, DANIEL), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(DANIEL, CARL, GEORGE, BENSON, FIONA, ALICE, ELLE), model.getFilteredPersonList());
     }
 
     @Test
     public void execute_priorityDescendingNameAscending_success() {
         SortCommand command = ensureParseSuccess("p>  name<");
         command.execute(model, null);
-        assertEquals(Arrays.asList(DANIEL, CARL, GEORGE, BENSON, FIONA, ALICE, ELLE), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(ALICE, ELLE, BENSON, FIONA, CARL, GEORGE, DANIEL), model.getFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -43,6 +43,16 @@ public class FilterCommandParserTest {
         assertParseSuccess(parser, "n<\"Hello World\"");
         assertParseSuccess(parser, "n:Test");
 
+        assertParseSuccess(parser, "p>1");
+        assertParseSuccess(parser, "p:1");
+        assertParseSuccess(parser, "p<1");
+        assertParseSuccess(parser, "p=1");
+        assertParseSuccess(parser, "p:0");
+        assertParseSuccess(parser, "p:2");
+        assertParseSuccess(parser, "p:3");
+        assertParseSuccess(parser, "p:4");
+        assertParseSuccess(parser, "p:\"3\"");
+
         assertParseSuccess(parser, "t:CS2101,CS2103");
         assertParseSuccess(parser, "t:CS2101");
         assertParseSuccess(parser, "t:\"CS2101,CS2103\"");
@@ -105,6 +115,8 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "d=");
         assertParseThrowsException(parser, "d>");
         assertParseThrowsException(parser, "d");
+        assertParseThrowsException(parser, "p:5");
+        assertParseThrowsException(parser, "p:b");
         assertParseThrowsException(parser, "=");
         assertParseThrowsException(parser, ":");
         assertParseThrowsException(parser, "-");

--- a/src/test/java/seedu/address/model/task/PriorityTest.java
+++ b/src/test/java/seedu/address/model/task/PriorityTest.java
@@ -44,8 +44,8 @@ public class PriorityTest {
         Priority a = new Priority("3");
         Priority b = new Priority("4");
         Priority c = new Priority(3);
-        assertTrue(a.compareTo(b) == -1);
-        assertTrue(b.compareTo(a) == 1);
+        assertTrue(a.compareTo(b) == 1);
+        assertTrue(b.compareTo(a) == -1);
         assertTrue(a.compareTo(c) == 0);
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -30,7 +30,7 @@ public class PersonUtil {
     public static String getPersonDetails(Task task) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME + task.getName().value + " ");
-        sb.append(PREFIX_PRIORITY + task.getPriority().value + " ");
+        sb.append(PREFIX_PRIORITY + task.getPriority().toString() + " ");
         sb.append(PREFIX_DEADLINE + task.getDeadline().toString() + " ");
         task.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
@@ -46,7 +46,7 @@ public class PersonUtil {
         descriptor.getName()
             .ifPresent(name -> sb.append(PREFIX_NAME).append(name.value).append(" "));
         descriptor.getPriority()
-            .ifPresent(priority -> sb.append(PREFIX_PRIORITY).append(priority.value).append(" "));
+            .ifPresent(priority -> sb.append(PREFIX_PRIORITY).append(priority.toString()).append(" "));
         descriptor.getDeadline()
             .ifPresent(deadline -> sb.append(PREFIX_DEADLINE).append(deadline.toString()).append(" "));
         if (descriptor.getTags().isPresent()) {


### PR DESCRIPTION
Filter can now filter by priority using "filter p:3" and "filter priority:3" syntax.  This resolves #82.

The Priority class has also been modified to internally store the priority as `int` instead of `String`.  This simplifies implementation of `compareTo()` and `equals()`, and is consistent with the implementation of Deadline (which stores a `java.util.Date`).