### PR TITLE
 Rewrite Import Export events handling and rewrite Import Conflict Resolver

### DIFF
--- a/src/main/java/seedu/address/commons/core/EventsCenter.java
+++ b/src/main/java/seedu/address/commons/core/EventsCenter.java
@@ -34,6 +34,10 @@ public class EventsCenter {
         eventBus.register(handler);
     }
 
+    public void unregisterHandler(Object handler) {
+        eventBus.unregister(handler);
+    }
+
     /**
      * Posts an event to the event bus.
      */

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -2,6 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.eventbus.Subscribe;
+
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -16,6 +20,8 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Exported successfully to external file: %s";
     public static final String MESSAGE_USAGE = "export filename";
     private String pathName;
+    private String exportError = "";
+
     public ExportCommand(String filename) {
         this.pathName = filename;
         //this.pathName = Paths.get(filename);
@@ -24,12 +30,22 @@ public class ExportCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        EventsCenter.getInstance().registerHandler(this);
         model.exportTaskCollection(pathName);
-        if (model.importExportFailed()) {
-            String errorMessage = model.getLastError();
-            throw new CommandException(String.format(MESSAGE_EXPORT_ERROR, errorMessage));
+        EventsCenter.getInstance().unregisterHandler(this);
+        if (hasExportError()) {
+            throw new CommandException(String.format(MESSAGE_EXPORT_ERROR, exportError));
         } else {
             return new CommandResult(String.format(MESSAGE_SUCCESS, pathName));
         }
+    }
+
+    private boolean hasExportError() {
+        return !(exportError.equals(""));
+    }
+
+    @Subscribe
+    public void handleImportExportExceptionEvent(ImportExportExceptionEvent event) {
+        exportError = event.toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -3,6 +3,10 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.ModelManager.ImportConflictMode;
 
+import com.google.common.eventbus.Subscribe;
+
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -18,6 +22,7 @@ public class ImportCommand extends Command {
     public static final String MESSAGE_USAGE = "import filename";
     private String fileName;
     private ImportConflictMode conflictResolver;
+    private String importError = "";
 
     public ImportCommand(String fileName) {
         this(fileName, ImportConflictMode.IGNORE);
@@ -30,13 +35,24 @@ public class ImportCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        EventsCenter.getInstance().registerHandler(this);
         model.importTaskCollection(fileName, conflictResolver);
-        if (model.importExportFailed()) {
-            String errorMessage = model.getLastError();
-            throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, errorMessage));
+        EventsCenter.getInstance().unregisterHandler(this);
+        if (hasImportError()) {
+            throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, importError));
         } else {
             //model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
             return new CommandResult(String.format(MESSAGE_SUCCESS, fileName));
         }
     }
+
+    private boolean hasImportError() {
+        return !(importError.equals(""));
+    }
+
+    @Subscribe
+    public void handleImportExportExceptionEvent(ImportExportExceptionEvent event) {
+        importError = event.toString();
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.ModelManager.ImportConflictMode;
 
 import com.google.common.eventbus.Subscribe;
 
@@ -9,6 +8,8 @@ import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.IgnoreImportConflictResolver;
+import seedu.address.model.ImportConflictResolver;
 import seedu.address.model.Model;
 
 /**
@@ -19,15 +20,17 @@ public class ImportCommand extends Command {
     public static final String COMMAND_WORD = "import";
     public static final String MESSAGE_IMPORT_ERROR = "Import failed. Error: %s";
     public static final String MESSAGE_SUCCESS = "Imported successfully from file: %s";
-    public static final String MESSAGE_USAGE = "import filename";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": imports a prevously saved file. "
+        + "Usage: import f/filename [r/all | r/overwrite | r/skip] \n"
+        + "Example: import f/saveFile.xml r/overwrite";
     private String fileName;
-    private ImportConflictMode conflictResolver;
+    private ImportConflictResolver conflictResolver;
     private String importError = "";
 
     public ImportCommand(String fileName) {
-        this(fileName, ImportConflictMode.IGNORE);
+        this(fileName, new IgnoreImportConflictResolver());
     }
-    public ImportCommand(String fileName, ImportConflictMode conflictResolver) {
+    public ImportCommand(String fileName, ImportConflictResolver conflictResolver) {
         this.fileName = fileName;
         this.conflictResolver = conflictResolver;
     }
@@ -44,6 +47,15 @@ public class ImportCommand extends Command {
             //model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
             return new CommandResult(String.format(MESSAGE_SUCCESS, fileName));
         }
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof ImportCommand // instanceof handles nulls
+            && fileName.equals(((ImportCommand) other).fileName)
+            && conflictResolver.getClass().equals(((ImportCommand) other).conflictResolver.getClass())); // state check
     }
 
     private boolean hasImportError() {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,4 +14,7 @@ public class CliSyntax {
     /* Prefix definitions for attachments */
     public static final Prefix PREFIX_FILEPATH = new Prefix("p/");
     public static final Prefix PREFIX_FILENAME = new Prefix("n/");
+
+    /* Prefix definitions for import command */
+    public static final Prefix PREFIX_RESOLVER = new Prefix("r/");
 }

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,18 +1,23 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.model.ModelManager.ImportConflictMode;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILENAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RESOLVER;
+import static seedu.address.logic.parser.ParserUtil.parseFileName;
+
+import java.util.Optional;
 
 import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.DuplicateImportConflictResolver;
+import seedu.address.model.IgnoreImportConflictResolver;
+import seedu.address.model.ImportConflictResolver;
+import seedu.address.model.OverwriteImportConflictResolver;
 
 /**
  * Parses input arguments and creates a new ImportCommand object
  */
 public class ImportCommandParser implements Parser<ImportCommand> {
-
-    public static final String FILENAME_CONSTRAINT = "Invalid filename! File name can only contain alphanumeric"
-        + " characters, full stop and the underscore [_] characters";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ImportCommand and returns an
@@ -21,37 +26,43 @@ public class ImportCommandParser implements Parser<ImportCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public ImportCommand parse(String args) throws ParseException {
-        String[] input = args.trim().split("\\s+");
-        if (input.length == 0) {
+
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer
+                .tokenize(args, PREFIX_FILENAME, PREFIX_RESOLVER);
+
+        String filename = argMultimap.getValue(PREFIX_FILENAME).orElseThrow(() -> new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE)));
+        String checkedFilename = parseFileName(filename);
+
+        ImportConflictResolver resolver;
+        Optional<String> resolverInput = argMultimap.getValue(PREFIX_RESOLVER);
+        if (resolverInput.isPresent()) {
+            resolver = resolverParser(resolverInput.get());
+        } else {
+            resolver = new IgnoreImportConflictResolver();
+        }
+
+        return new ImportCommand(checkedFilename, resolver);
+    }
+
+    /**
+     * Determines which resolver to use based on the user input.
+     * @param input user command arguments
+     * @return the appropriate ImportConflictResolver
+     * @throws ParseException if user's argument is not recognised
+     */
+    private ImportConflictResolver resolverParser(String input) throws ParseException {
+        switch (input) {
+        case "all":
+            return new DuplicateImportConflictResolver();
+        case "overwrite":
+            return new OverwriteImportConflictResolver();
+        case "skip":
+            return new IgnoreImportConflictResolver();
+        default:
             throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
         }
-        String filename = input[0].trim();
-        if (!validFileName(filename)) {
-            throw new ParseException(FILENAME_CONSTRAINT);
-        }
-        if (input.length == 1) {
-            return new ImportCommand(filename);
-        } else {
-            String option = input[1].trim();
-            switch (option) {
-            case "/all":
-                return new ImportCommand(filename, ImportConflictMode.DUPLICATE);
-            case "/overwrite":
-                return new ImportCommand(filename, ImportConflictMode.OVERWRITE);
-            case "/skip":
-                return new ImportCommand(filename, ImportConflictMode.IGNORE);
-            default:
-                throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
-            }
-        }
-
-
     }
-
-    private boolean validFileName(String filename) {
-        return filename.matches("^[a-zA-Z0-9_.]+$");
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -20,6 +20,8 @@ import seedu.address.model.task.Priority;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_FILENAME = "Invalid filename! File name can only contain alphanumeric"
+        + " characters, full stop and the underscore [_] characters";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing
@@ -106,5 +108,19 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses and determines if a filename is legal.
+     * A filename is legal if it uses only alphanumeric characters, the underscore, or fullstop characters.
+     * @param filename the filename to be checked
+     * @return the fileName if it is legal
+     * @throws ParseException if filename is illegal
+     */
+    public static String parseFileName(String filename) throws ParseException {
+        if (!filename.matches("^[a-zA-Z0-9_.]+$")) {
+            throw new ParseException(MESSAGE_INVALID_FILENAME);
+        }
+        return filename;
     }
 }

--- a/src/main/java/seedu/address/model/DuplicateImportConflictResolver.java
+++ b/src/main/java/seedu/address/model/DuplicateImportConflictResolver.java
@@ -1,0 +1,20 @@
+package seedu.address.model;
+
+import java.util.function.Consumer;
+
+import seedu.address.model.task.Task;
+
+/**
+ * The DuplicateImportConflictResolver class.
+ * This class will resolve import conflicts by duplicating entries, i.e. after the resolver is complete,
+ * both entries from the existing and imported TaskCollection will be saved.
+ */
+public class DuplicateImportConflictResolver extends ImportConflictResolver {
+
+    @Override
+    public void resolve(Consumer<Task> addTask, Consumer<Task> removeTask, Task task) {
+        //Ignore task.
+        LOGGER.info("Duplicating task");
+        addTask.accept(task);
+    }
+}

--- a/src/main/java/seedu/address/model/IgnoreImportConflictResolver.java
+++ b/src/main/java/seedu/address/model/IgnoreImportConflictResolver.java
@@ -1,0 +1,19 @@
+package seedu.address.model;
+
+import java.util.function.Consumer;
+
+import seedu.address.model.task.Task;
+
+/**
+ * The DuplicateImportConflictResolver class.
+ * This class will resolve import conflicts by ignoring the incoming entry, i.e. after the resolver is complete,
+ * the existing entry in the TaskCollection will remain.
+ */
+public class IgnoreImportConflictResolver extends ImportConflictResolver {
+
+    @Override
+    public void resolve(Consumer<Task> addTask, Consumer<Task> removeTask, Task task) {
+        //Ignore task.
+        LOGGER.info("Ignoring task");
+    }
+}

--- a/src/main/java/seedu/address/model/ImportConflictResolver.java
+++ b/src/main/java/seedu/address/model/ImportConflictResolver.java
@@ -1,0 +1,17 @@
+package seedu.address.model;
+
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.task.Task;
+
+/**
+ * The base ImportConflictResolver class.
+ * Instantiates a logger for child classes to use.
+ * Has a single abstract method resolve, which takes in the add and remove methods to be applied to a task.
+ */
+public abstract class ImportConflictResolver {
+    protected static final Logger LOGGER = LogsCenter.getLogger(ImportConflictResolver.class);
+    abstract void resolve(Consumer<Task> addTask, Consumer<Task> removeTask, Task task);
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -96,19 +96,14 @@ public interface Model {
      */
     void commitTaskCollection();
 
-    boolean importExportFailed();
+    /*boolean importExportFailed();
 
-    String getLastError();
+    String getLastError();*/
 
     /**
      * Exports current deadline manager to file.
      */
     void exportTaskCollection(String filename);
-
-    /**
-     * Imports tasks from file to the current deadline manager.
-     */
-    void importTaskCollection(String filename);
 
     /**
      * Imports tasks from file to the current deadline manager.
@@ -122,6 +117,4 @@ public interface Model {
     @Subscribe
     void handleImportDataAvailableEvent(ImportDataAvailableEvent event);
 
-    @Subscribe
-    void handleImportExportExceptionEvent(ImportExportExceptionEvent event);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,7 +7,6 @@ import com.google.common.eventbus.Subscribe;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.events.storage.ImportDataAvailableEvent;
-import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.model.task.Task;
 
 /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -107,7 +107,7 @@ public interface Model {
     /**
      * Imports tasks from file to the current deadline manager.
      */
-    void importTaskCollection(String filename, ModelManager.ImportConflictMode mode);
+    void importTaskCollection(String filename, ImportConflictResolver mode);
 
     /**
      * Handler for the return result from Storage, when import data has been read.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -19,7 +19,6 @@ import seedu.address.commons.events.model.ExportRequestEvent;
 import seedu.address.commons.events.model.ImportRequestEvent;
 import seedu.address.commons.events.model.TaskCollectionChangedEvent;
 import seedu.address.commons.events.storage.ImportDataAvailableEvent;
-import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.model.task.Task;
 
 
@@ -178,14 +177,6 @@ public class ModelManager extends ComponentManager implements Model {
 
     //==========Import/Export===================================================================
 
-    public boolean importExportFailed() {
-        return lastError != null;
-    }
-    public String getLastError() {
-        String err = lastError;
-        lastError = null;
-        return err;
-    }
     @Override
     public void exportTaskCollection(String filename) {
         requireNonNull(filename);
@@ -193,11 +184,6 @@ public class ModelManager extends ComponentManager implements Model {
         TaskCollection exportCollection = new TaskCollection();
         exportCollection.setTasks(lastShownList);
         raise(new ExportRequestEvent(exportCollection, filename));
-    }
-
-    @Override
-    public void importTaskCollection(String filename) {
-        importTaskCollection(filename, ImportConflictMode.IGNORE);
     }
 
     @Override
@@ -218,11 +204,6 @@ public class ModelManager extends ComponentManager implements Model {
         updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
     }
 
-    @Override
-    @Subscribe
-    public void handleImportExportExceptionEvent(ImportExportExceptionEvent event) {
-        lastError = event.toString();
-    }
 
     /**
      * Use the appropriate import conflict handler to resolve a conflict.

--- a/src/main/java/seedu/address/model/OverwriteImportConflictResolver.java
+++ b/src/main/java/seedu/address/model/OverwriteImportConflictResolver.java
@@ -1,0 +1,21 @@
+package seedu.address.model;
+
+import java.util.function.Consumer;
+
+import seedu.address.model.task.Task;
+
+/**
+ * The OverwriteImportConflictResolver class.
+ * This class will resolve import conflicts by overwriting entries, i.e. after the resolver is complete,
+ * the newly imported Task will overwrite the existing task in the TaskCollection.
+ */
+public class OverwriteImportConflictResolver extends ImportConflictResolver {
+
+    @Override
+    public void resolve(Consumer<Task> addTask, Consumer<Task> removeTask, Task task) {
+        //Ignore task.
+        LOGGER.info("Updating task");
+        removeTask.accept(task);
+        addTask.accept(task);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -9,7 +9,9 @@ import org.junit.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.ModelManager;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.task.Task;
 import seedu.address.storage.Storage;
@@ -23,26 +25,33 @@ public class ExportCommandTest {
     public final String temporaryFilePath = "dummySaveFile";
     private CommandHistory commandHistory = new CommandHistory();
     private String defaultFile = "fakeDefaultPath";
-    private ModelStubWithExportAddressBook modelStub = new ModelStubWithExportAddressBook(defaultFile);
 
     @Test
     public void execute_exportOnWorkingFile_exceptionThrown() {
         IOException expectedException = new IOException(StorageManager.MESSAGE_WRITE_FILE_EXISTS_ERROR);
-        assertCommandFailure(new ExportCommand(defaultFile), modelStub, commandHistory,
+        ExportCommand testCommand = new ExportCommand(defaultFile);
+        ModelStubWithExportAddressBook modelStub = new ModelStubWithExportAddressBook(defaultFile, testCommand);
+        assertCommandFailure(testCommand, modelStub, commandHistory,
                 String.format(ExportCommand.MESSAGE_EXPORT_ERROR, expectedException.toString()));
     }
 
     @Test
     public void execute_exportNewFile_exportSuccessful() {
-        assertCommandSuccess(new ExportCommand(temporaryFilePath), modelStub,
-                commandHistory, String.format(ExportCommand.MESSAGE_SUCCESS, temporaryFilePath), modelStub);
+        ExportCommand testCommand = new ExportCommand(temporaryFilePath);
+        ModelStubWithExportAddressBook modelStub = new ModelStubWithExportAddressBook(defaultFile, testCommand);
+        assertCommandSuccess(testCommand, modelStub, commandHistory,
+                 String.format(ExportCommand.MESSAGE_SUCCESS, temporaryFilePath), modelStub);
     }
 
     private class ModelStubWithExportAddressBook extends ModelStub {
         private String filename = "";
-        private String lastError = null;
+        private ExportCommand testCommand = null;
         public ModelStubWithExportAddressBook(String defaultFile) {
             filename = defaultFile;
+        }
+        public ModelStubWithExportAddressBook(String defaultFile, ExportCommand importCommand) {
+            this(defaultFile);
+            testCommand = importCommand;
         }
 
         @Override
@@ -58,18 +67,11 @@ public class ExportCommandTest {
         @Override
         public void exportTaskCollection(String filename) {
             if (filename.equals(this.filename)) {
-                lastError = new IOException(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR).toString();
+                Exception fileExistException = new IOException(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR);
+                testCommand.handleImportExportExceptionEvent(new ImportExportExceptionEvent(fileExistException));
+                return;
             }
-        }
-
-        @Override
-        public boolean importExportFailed() {
-            return lastError != null;
-        }
-
-        @Override
-        public String getLastError() {
-            return lastError;
+            //No error otherwise.
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -11,7 +11,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.ModelManager;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.task.Task;
 import seedu.address.storage.Storage;

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.model.TaskCollection;
@@ -25,26 +26,33 @@ public class ImportCommandTest {
     public final String doesNotExistPath = "doesNotExist";
     private CommandHistory commandHistory = new CommandHistory();
     private String defaultFile = "fakeDefaultPath";
-    private ModelStubWithImportAddressBook modelStub = new ModelStubWithImportAddressBook(defaultFile);
 
     @Test
     public void execute_importMissingFile_exceptionThrown() {
         IOException expectedException = new IOException(StorageManager.MESSAGE_READ_FILE_MISSING_ERROR);
-        assertCommandFailure(new ImportCommand(doesNotExistPath), modelStub, commandHistory,
+        ImportCommand testCommand = new ImportCommand(doesNotExistPath);
+        ModelStubWithImportAddressBook modelStub = new ModelStubWithImportAddressBook(defaultFile, testCommand);
+        assertCommandFailure(testCommand, modelStub, commandHistory,
                 String.format(ImportCommand.MESSAGE_IMPORT_ERROR, expectedException.toString()));
     }
 
     @Test
     public void execute_importExistingFile_importSuccessful() {
-        assertCommandSuccess(new ImportCommand(temporaryFilePath), modelStub,
-                commandHistory, String.format(ImportCommand.MESSAGE_SUCCESS, temporaryFilePath), modelStub);
+        ImportCommand testCommand = new ImportCommand(temporaryFilePath);
+        ModelStubWithImportAddressBook modelStub = new ModelStubWithImportAddressBook(defaultFile, testCommand);
+        assertCommandSuccess(testCommand, modelStub, commandHistory,
+                String.format(ImportCommand.MESSAGE_SUCCESS, temporaryFilePath), modelStub);
     }
 
     private class ModelStubWithImportAddressBook extends ModelStub {
         private String filename = "";
-        private String lastError = null;
+        private ImportCommand testCommand = null;
         public ModelStubWithImportAddressBook(String defaultFile) {
             filename = defaultFile;
+        }
+        public ModelStubWithImportAddressBook(String defaultFile, ImportCommand importCommand) {
+            this(defaultFile);
+            testCommand = importCommand;
         }
 
         @Override
@@ -58,36 +66,23 @@ public class ImportCommandTest {
         }
 
         @Override
-        public void importTaskCollection(String filename) {
-            importTaskCollection(filename, ImportConflictMode.IGNORE);
-        }
-
-        @Override
         public void importTaskCollection(String filename, ImportConflictMode conflictMode) {
             if (filename.equals(temporaryFilePath)) {
                 //No error.
                 return;
             }
             if (filename.equals(this.filename)) {
-                lastError = new IOException(Storage.MESSAGE_READ_FILE_SAME_ERROR).toString();
+                Exception fileRepeatException = new IOException(Storage.MESSAGE_READ_FILE_SAME_ERROR);
+                testCommand.handleImportExportExceptionEvent(new ImportExportExceptionEvent(fileRepeatException));
                 return;
             }
             if (filename.equals(doesNotExistPath)) {
-                lastError = new IOException(Storage.MESSAGE_READ_FILE_MISSING_ERROR).toString();
+                Exception fileMissingException = new IOException(Storage.MESSAGE_READ_FILE_MISSING_ERROR);
+                testCommand.handleImportExportExceptionEvent(new ImportExportExceptionEvent(fileMissingException));
                 return;
             }
-            lastError = new AssertionError("Should not use this filename").toString();
+            throw new AssertionError("Should not use this filename");
 
-        }
-
-        @Override
-        public boolean importExportFailed() {
-            return lastError != null;
-        }
-
-        @Override
-        public String getLastError() {
-            return lastError;
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -11,7 +11,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.ModelManager.ImportConflictMode;
+import seedu.address.model.ImportConflictResolver;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.task.Task;
 import seedu.address.storage.Storage;
@@ -66,7 +66,7 @@ public class ImportCommandTest {
         }
 
         @Override
-        public void importTaskCollection(String filename, ImportConflictMode conflictMode) {
+        public void importTaskCollection(String filename, ImportConflictResolver conflictMode) {
             if (filename.equals(temporaryFilePath)) {
                 //No error.
                 return;

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -4,8 +4,8 @@ import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.events.storage.ImportDataAvailableEvent;
-import seedu.address.commons.events.storage.ImportExportExceptionEvent;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.model.ReadOnlyTaskCollection;
@@ -14,7 +14,7 @@ import seedu.address.model.task.Task;
 /**
  * A default model stub that have all of the methods failing.
  */
-public class ModelStub implements Model {
+public class ModelStub extends ComponentManager implements Model {
 
     @Override
     public void addTask(Task task) {
@@ -87,24 +87,10 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public boolean importExportFailed() {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public String getLastError() {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
     public void exportTaskCollection(String filename) {
         throw new AssertionError("This method should not be called.");
     }
 
-    @Override
-    public void importTaskCollection(String filename) {
-        throw new AssertionError("This method should not be called.");
-    }
 
     @Override
     public void importTaskCollection(String filename, ImportConflictMode conflictMode) {
@@ -116,8 +102,4 @@ public class ModelStub implements Model {
         throw new AssertionError("This method should not be called.");
     }
 
-    @Override
-    public void handleImportExportExceptionEvent(ImportExportExceptionEvent event) {
-        throw new AssertionError("This method should not be called.");
-    }
 }

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -6,8 +6,8 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.events.storage.ImportDataAvailableEvent;
+import seedu.address.model.ImportConflictResolver;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager.ImportConflictMode;
 import seedu.address.model.ReadOnlyTaskCollection;
 import seedu.address.model.task.Task;
 
@@ -91,9 +91,8 @@ public class ModelStub extends ComponentManager implements Model {
         throw new AssertionError("This method should not be called.");
     }
 
-
     @Override
-    public void importTaskCollection(String filename, ImportConflictMode conflictMode) {
+    public void importTaskCollection(String filename, ImportConflictResolver conflictMode) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
@@ -1,0 +1,87 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.model.DuplicateImportConflictResolver;
+import seedu.address.model.IgnoreImportConflictResolver;
+import seedu.address.model.OverwriteImportConflictResolver;
+
+/**
+ * Test scope: Import command parser.
+ * Tests for valid and invalid filenames, as well as valid and invalid command arguments
+ */
+public class ImportCommandParserTest {
+
+    private ImportCommandParser parser = new ImportCommandParser();
+
+    @Test
+    public void parse_noFile_throwsParseException() {
+        assertParseFailure(parser, "",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidCommand_throwsParseException() {
+        assertParseFailure(parser, " ab",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " r/all",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " n",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " n/all r/",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " a*b",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidFileName_throwsParseException() {
+        assertParseFailure(parser, " n/a/b", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n//all", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n/b/", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n/a-b", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n/ ", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n/文件", ParserUtil.MESSAGE_INVALID_FILENAME);
+    }
+
+    @Test
+    public void parse_validFileName_returnsImportCommand() {
+        assertParseSuccess(parser, " n/ab", new ImportCommand("ab"));
+        assertParseSuccess(parser, " n/a_b", new ImportCommand("a_b"));
+        assertParseSuccess(parser, " n/veryverylongname", new ImportCommand("veryverylongname"));
+        assertParseSuccess(parser, " n/fullstop.txt", new ImportCommand("fullstop.txt"));
+        assertParseSuccess(parser, " n/filename_xml.txt", new ImportCommand("filename_xml.txt"));
+    }
+
+    @Test
+    public void parse_invalidFileNameParameters_throwsParseException() {
+        assertParseFailure(parser, " n/ab c/what", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n/a*b r/all", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n/   r/all", ParserUtil.MESSAGE_INVALID_FILENAME);
+        assertParseFailure(parser, " n/file r/override",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " n/file r/invalid",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " n/wrongCommand r//all",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validFileNameParameters_returnsImportCommand() {
+        assertParseSuccess(parser, " n/ab r/all",
+            new ImportCommand("ab", new DuplicateImportConflictResolver()));
+        assertParseSuccess(parser, " n/a_b",
+            new ImportCommand("a_b", new IgnoreImportConflictResolver()));
+        assertParseSuccess(parser, " n/veryverylongname r/overwrite",
+            new ImportCommand("veryverylongname", new OverwriteImportConflictResolver()));
+        assertParseSuccess(parser, " n/fullstop.txt r/all",
+            new ImportCommand("fullstop.txt", new DuplicateImportConflictResolver()));
+        assertParseSuccess(parser, " n/filename_xml.txt r/skip",
+            new ImportCommand("filename_xml.txt", new IgnoreImportConflictResolver()));
+    }
+}


### PR DESCRIPTION
Previously, import and export errors were handled by Model.
This resulted in coupling with ImportCommand and ExportCommand.
Rewrote to ensure event driven style of development.

Rewrote import conflict resolver to use OOP.

These are 2 separate features but combined as 1 PR as I forgot to merge the first PR ><