### PR TITLE
UserGuide: Remove 'search' command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -230,12 +230,6 @@ Returns a subset of the current list of tasks that has the tag "CS2103T".
 * `filter t:CS2103T,CS2101`
 Returns a subset of the current list of tasks that has both the tags "CS2103T" and "CS2101".
 
-=== Filtering a list of tasks: `search`
-
-Filters the current list of tasks with a specified filter predicate.
-
-This is an alias for `filter`.  They perform exactly the same function.  The alias is provided because it is sometimes more intuitive to think of certain filter operations as 'search' operations, e.g. searching for a task that has a particular name.
-
 //TODO: Sidhant
 === Sorting a list of tasks : `sort`
 


### PR DESCRIPTION
We will not be implementing 'search'.  Originally it was intended that 'search' is an alias for 'filter'.