### PR TITLE
Change ArgumentTokenizer to be aware of how many times an argument can appear

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.task.Frequency.NO_FREQUENCY;
 import static seedu.address.model.task.Priority.NO_PRIORITY;
 
+import java.util.InputMismatchException;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -43,9 +44,15 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
+        ArgumentMultimap argMultimap;
+        try {
+            argMultimap =
                 ArgumentTokenizer
-                        .tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_FREQUENCY, PREFIX_DEADLINE, PREFIX_TAG);
+                    .tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_FREQUENCY, PREFIX_DEADLINE, PREFIX_TAG);
+        } catch (InputMismatchException ime) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE), ime);
+        }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DEADLINE)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.InputMismatchException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,8 +28,11 @@ public class ArgumentMultimap {
      * @param prefix   Prefix key with which the specified argument value is to be associated
      * @param argValue Argument value to be associated with the specified prefix key
      */
-    public void put(Prefix prefix, String argValue) {
+    public void put(Prefix prefix, String argValue) throws InputMismatchException {
         List<String> argValues = getAllValues(prefix);
+        if (argValues.size() != 0 && !prefix.canOccurMultipleTimes()) {
+            throw new InputMismatchException("Multiple occurrences of prefix that should not repeat.");
+        }
         argValues.add(argValue);
         argMultimap.put(prefix, argValues);
     }
@@ -58,6 +62,6 @@ public class ArgumentMultimap {
      * spaces.
      */
     public String getPreamble() {
-        return getValue(new Prefix("")).orElse("");
+        return getValue(new Prefix("", true)).orElse("");
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -62,6 +62,6 @@ public class ArgumentMultimap {
      * spaces.
      */
     public String getPreamble() {
-        return getValue(new Prefix("", true)).orElse("");
+        return getValue(Prefix.EMPTY).orElse("");
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -36,21 +36,6 @@ public class ArgumentTokenizer {
     }
 
     /**
-     * Ensures that the given list of prefixes are all unique in their prefix string.
-     * Throws a (@code IllegalArgumentException) if not all prefixes are unique.
-     */
-    public static void checkUniquePrefixes(Prefix... prefixes) {
-        HashSet<String> prefixStringSet = new HashSet<>();
-        for (int i = 0; i != prefixes.length; ++i) {
-            String prefixString = prefixes[i].getPrefix();
-            if (prefixStringSet.contains(prefixString)) {
-                throw new IllegalArgumentException("Prefixes for parsing is not unique");
-            }
-            prefixStringSet.add(prefixString);
-        }
-    }
-
-    /**
      * Extracts prefixes and their argument values based on the given pattern and input tokenizer,
      * and returns an {@code ArgumentMultimap} object that maps the extracted prefixes to their respective arguments.
      *
@@ -84,6 +69,21 @@ public class ArgumentTokenizer {
         }
         argMultimap.put(currPrefix, currArgumentValue.toString());
         return argMultimap;
+    }
+
+    /**
+     * Ensures that the given list of prefixes are all unique in their prefix string.
+     * Throws a (@code IllegalArgumentException) if not all prefixes are unique.
+     */
+    public static void checkUniquePrefixes(Prefix... prefixes) {
+        HashSet<String> prefixStringSet = new HashSet<>();
+        for (int i = 0; i != prefixes.length; ++i) {
+            String prefixString = prefixes[i].getPrefix();
+            if (prefixStringSet.contains(prefixString)) {
+                throw new IllegalArgumentException("Prefixes for parsing is not unique");
+            }
+            prefixStringSet.add(prefixString);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import java.util.HashSet;
 import java.util.InputMismatchException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,8 +30,24 @@ public class ArgumentTokenizer {
         if (prefixes.length == 0) {
             return tokenizeWithoutPrefix(tokenizer, argsString);
         }
+        checkUniquePrefixes(prefixes);
         Pattern pattern = makePattern(prefixes);
         return tokenize(tokenizer, pattern, prefixes);
+    }
+
+    /**
+     * Ensures that the given list of prefixes are all unique in their prefix string.
+     * Throws a (@code IllegalArgumentException) if not all prefixes are unique.
+     */
+    public static void checkUniquePrefixes(Prefix... prefixes) {
+        HashSet<String> prefixStringSet = new HashSet<>();
+        for (int i = 0; i != prefixes.length; ++i) {
+            String prefixString = prefixes[i].getPrefix();
+            if (prefixStringSet.contains(prefixString)) {
+                throw new IllegalArgumentException("Prefixes for parsing is not unique");
+            }
+            prefixStringSet.add(prefixString);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -45,7 +45,7 @@ public class ArgumentTokenizer {
     private static ArgumentMultimap tokenize(StringTokenizer tokenizer, Pattern pattern, Prefix... prefixes)
         throws InputMismatchException {
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        Prefix currPrefix = new Prefix("");
+        Prefix currPrefix = new Prefix("", true);
         StringBuilder currArgumentValue = new StringBuilder();
         boolean isEmpty = true;
         while (tokenizer.hasNextToken()) {
@@ -88,7 +88,7 @@ public class ArgumentTokenizer {
             }
             currArgumentValue.append(textToken);
         }
-        argMultimap.put(new Prefix(""), currArgumentValue.toString());
+        argMultimap.put(new Prefix("", true), currArgumentValue.toString());
         return argMultimap;
     }
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -45,7 +45,7 @@ public class ArgumentTokenizer {
     private static ArgumentMultimap tokenize(StringTokenizer tokenizer, Pattern pattern, Prefix... prefixes)
         throws InputMismatchException {
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        Prefix currPrefix = new Prefix("", false);
+        Prefix currPrefix = Prefix.EMPTY;
         StringBuilder currArgumentValue = new StringBuilder();
         boolean isEmpty = true;
         while (tokenizer.hasNextToken()) {
@@ -88,7 +88,7 @@ public class ArgumentTokenizer {
             }
             currArgumentValue.append(textToken);
         }
-        argMultimap.put(new Prefix("", false), currArgumentValue.toString());
+        argMultimap.put(Prefix.EMPTY, currArgumentValue.toString());
         return argMultimap;
     }
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -45,7 +45,7 @@ public class ArgumentTokenizer {
     private static ArgumentMultimap tokenize(StringTokenizer tokenizer, Pattern pattern, Prefix... prefixes)
         throws InputMismatchException {
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        Prefix currPrefix = new Prefix("", true);
+        Prefix currPrefix = new Prefix("", false);
         StringBuilder currArgumentValue = new StringBuilder();
         boolean isEmpty = true;
         while (tokenizer.hasNextToken()) {
@@ -88,7 +88,7 @@ public class ArgumentTokenizer {
             }
             currArgumentValue.append(textToken);
         }
-        argMultimap.put(new Prefix("", true), currArgumentValue.toString());
+        argMultimap.put(new Prefix("", false), currArgumentValue.toString());
         return argMultimap;
     }
 

--- a/src/main/java/seedu/address/logic/parser/AttachmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AttachmentCommandParser.java
@@ -11,6 +11,8 @@ import static seedu.address.logic.commands.AttachmentCommand.MESSAGE_MISSING_ARG
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILENAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILEPATH;
 
+import java.util.InputMismatchException;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AttachmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -28,9 +30,15 @@ public class AttachmentCommandParser implements Parser<AttachmentCommand> {
      */
     public AttachmentCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-            ArgumentTokenizer
-                .tokenize(args, PREFIX_FILEPATH, PREFIX_FILENAME);
+        ArgumentMultimap argMultimap;
+        try {
+            argMultimap =
+                ArgumentTokenizer
+                    .tokenize(args, PREFIX_FILEPATH, PREFIX_FILENAME);
+        } catch (InputMismatchException ime) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AttachmentCommand.MESSAGE_USAGE), ime);
+        }
 
         Index index;
         String actionWord;

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,16 +6,16 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PRIORITY = new Prefix("P/");
-    public static final Prefix PREFIX_FREQUENCY = new Prefix("f/");
-    public static final Prefix PREFIX_DEADLINE = new Prefix("d/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_NAME = new Prefix("n/", false);
+    public static final Prefix PREFIX_PRIORITY = new Prefix("P/", false);
+    public static final Prefix PREFIX_FREQUENCY = new Prefix("f/", false);
+    public static final Prefix PREFIX_DEADLINE = new Prefix("d/", false);
+    public static final Prefix PREFIX_TAG = new Prefix("t/", true);
 
     /* Prefix definitions for attachments */
-    public static final Prefix PREFIX_FILEPATH = new Prefix("p/");
-    public static final Prefix PREFIX_FILENAME = new Prefix("n/");
+    public static final Prefix PREFIX_FILEPATH = new Prefix("p/", false);
+    public static final Prefix PREFIX_FILENAME = new Prefix("n/", false);
 
     /* Prefix definitions for import command */
-    public static final Prefix PREFIX_RESOLVER = new Prefix("r/");
+    public static final Prefix PREFIX_RESOLVER = new Prefix("r/", false);
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,16 +6,16 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/", false);
-    public static final Prefix PREFIX_PRIORITY = new Prefix("P/", false);
-    public static final Prefix PREFIX_FREQUENCY = new Prefix("f/", false);
-    public static final Prefix PREFIX_DEADLINE = new Prefix("d/", false);
+    public static final Prefix PREFIX_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_PRIORITY = new Prefix("P/");
+    public static final Prefix PREFIX_FREQUENCY = new Prefix("f/");
+    public static final Prefix PREFIX_DEADLINE = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/", true);
 
     /* Prefix definitions for attachments */
-    public static final Prefix PREFIX_FILEPATH = new Prefix("p/", false);
-    public static final Prefix PREFIX_FILENAME = new Prefix("n/", false);
+    public static final Prefix PREFIX_FILEPATH = new Prefix("p/");
+    public static final Prefix PREFIX_FILENAME = new Prefix("n/");
 
     /* Prefix definitions for import command */
-    public static final Prefix PREFIX_RESOLVER = new Prefix("r/", false);
+    public static final Prefix PREFIX_RESOLVER = new Prefix("r/");
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.InputMismatchException;
 import java.util.Optional;
 import java.util.Set;
 
@@ -31,11 +32,16 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
+        ArgumentMultimap argMultimap;
+        try {
+            argMultimap =
                 ArgumentTokenizer
-                        .tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_FREQUENCY,
-                                PREFIX_DEADLINE, PREFIX_TAG);
-
+                    .tokenize(args, PREFIX_NAME, PREFIX_PRIORITY, PREFIX_FREQUENCY,
+                        PREFIX_DEADLINE, PREFIX_TAG);
+        } catch (InputMismatchException ime) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), ime);
+        }
         Index index;
 
         try {

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FILENAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RESOLVER;
 import static seedu.address.logic.parser.ParserUtil.parseFileName;
 
+import java.util.InputMismatchException;
 import java.util.Optional;
 
 import seedu.address.logic.commands.ExportCommand;
@@ -22,11 +23,15 @@ public class ExportCommandParser implements Parser<ExportCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public ExportCommand parse(String args) throws ParseException {
-
-        ArgumentMultimap argMultimap =
-            ArgumentTokenizer
-                .tokenize(args, PREFIX_FILENAME, PREFIX_RESOLVER);
-
+        ArgumentMultimap argMultimap;
+        try {
+            argMultimap =
+                ArgumentTokenizer
+                    .tokenize(args, PREFIX_FILENAME, PREFIX_RESOLVER);
+        } catch (InputMismatchException ime) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE), ime);
+        }
         String filename = argMultimap.getValue(PREFIX_FILENAME).orElseThrow(() -> new ParseException(
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE)));
         String checkedFilename = parseFileName(filename);

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FILENAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RESOLVER;
 import static seedu.address.logic.parser.ParserUtil.parseFileName;
 
+import java.util.InputMismatchException;
 import java.util.Optional;
 
 import seedu.address.logic.commands.ImportCommand;
@@ -26,11 +27,15 @@ public class ImportCommandParser implements Parser<ImportCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public ImportCommand parse(String args) throws ParseException {
-
-        ArgumentMultimap argMultimap =
-            ArgumentTokenizer
-                .tokenize(args, PREFIX_FILENAME, PREFIX_RESOLVER);
-
+        ArgumentMultimap argMultimap = null;
+        try {
+            argMultimap =
+                ArgumentTokenizer
+                    .tokenize(args, PREFIX_FILENAME, PREFIX_RESOLVER);
+        } catch (InputMismatchException ime) {
+            new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE), ime);
+        }
         String filename = argMultimap.getValue(PREFIX_FILENAME).orElseThrow(() -> new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE)));
         String checkedFilename = parseFileName(filename);

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -41,7 +41,7 @@ public class Prefix {
         }
 
         Prefix otherPrefix = (Prefix) obj;
-        return otherPrefix.getPrefix().equals(getPrefix()) &&
-            otherPrefix.canOccurMultipleTimes() == canOccurMultipleTimes();
+        return otherPrefix.getPrefix().equals(getPrefix())
+            && otherPrefix.canOccurMultipleTimes() == canOccurMultipleTimes();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -7,13 +7,19 @@ package seedu.address.logic.parser;
 public class Prefix {
 
     private final String prefix;
+    private final boolean hasMultiple;
 
-    public Prefix(String prefix) {
+    public Prefix(String prefix, boolean hasMultiple) {
         this.prefix = prefix;
+        this.hasMultiple = hasMultiple;
     }
 
     public String getPrefix() {
         return prefix;
+    }
+
+    public boolean canOccurMultipleTimes() {
+        return this.hasMultiple;
     }
 
     public String toString() {
@@ -35,6 +41,7 @@ public class Prefix {
         }
 
         Prefix otherPrefix = (Prefix) obj;
-        return otherPrefix.getPrefix().equals(getPrefix());
+        return otherPrefix.getPrefix().equals(getPrefix()) &&
+            otherPrefix.canOccurMultipleTimes() == canOccurMultipleTimes();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -6,6 +6,8 @@ package seedu.address.logic.parser;
  */
 public class Prefix {
 
+    public static final Prefix EMPTY = new Prefix("", false);
+
     private final String prefix;
     private final boolean hasMultiple;
 

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -6,14 +6,23 @@ package seedu.address.logic.parser;
  */
 public class Prefix {
 
-    public static final Prefix EMPTY = new Prefix("", false);
+    public static final Prefix EMPTY = new Prefix("");
 
     private final String prefix;
     private final boolean hasMultiple;
 
+
     public Prefix(String prefix, boolean hasMultiple) {
         this.prefix = prefix;
         this.hasMultiple = hasMultiple;
+    }
+
+    /**
+     * Convenience constructor that caters for the majority of the prefixes which cannot occur multiple times
+     */
+    public Prefix(String prefix) {
+        this.prefix = prefix;
+        this.hasMultiple = false;
     }
 
     public String getPrefix() {

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -47,6 +47,28 @@ public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
 
     @Test
+    public void parse_allFieldsPresentSomeFieldsDuplicate_failure() {
+        String expectedMessage = String
+            .format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+
+        // multiple names
+        assertParseFailure(parser, NAME_DESC_AMY + NAME_DESC_BOB
+                + PRIORITY_DESC_BOB + FREQUENCY_DESC_BOB + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, expectedMessage);
+
+        // multiple priorities
+        assertParseFailure(parser, NAME_DESC_BOB + PRIORITY_DESC_AMY + PRIORITY_DESC_BOB
+            + FREQUENCY_DESC_BOB + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, expectedMessage);
+
+        // multiple frequencies
+        assertParseFailure(parser, NAME_DESC_BOB + PRIORITY_DESC_BOB + FREQUENCY_DESC_AMY
+            + FREQUENCY_DESC_BOB + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, expectedMessage);
+
+        // multiple deadlines
+        assertParseFailure(parser, NAME_DESC_BOB + PRIORITY_DESC_BOB + FREQUENCY_DESC_BOB
+            + DEADLINE_DESC_AMY + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, expectedMessage);
+    }
+
+    @Test
     public void parse_allFieldsPresent_success() {
         Task expectedTask = new TaskBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
 
@@ -55,24 +77,7 @@ public class AddCommandParserTest {
             PREAMBLE_WHITESPACE + NAME_DESC_BOB + PRIORITY_DESC_BOB + FREQUENCY_DESC_BOB
                 + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedTask));
 
-        // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB
-            + PRIORITY_DESC_BOB + FREQUENCY_DESC_BOB + DEADLINE_DESC_BOB + TAG_DESC_FRIEND,
-            new AddCommand(expectedTask));
-
-        // multiple priorities - last priority accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PRIORITY_DESC_AMY + PRIORITY_DESC_BOB
-            + FREQUENCY_DESC_BOB + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedTask));
-
-        // multiple frequencies - last frequency accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PRIORITY_DESC_BOB + FREQUENCY_DESC_AMY
-            + FREQUENCY_DESC_BOB + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedTask));
-
-        // multiple deadlines - last deadline accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PRIORITY_DESC_BOB + FREQUENCY_DESC_BOB
-            + DEADLINE_DESC_AMY + DEADLINE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedTask));
-
-        // multiple tags - all accepted
+        // multiple tags are ok - all accepted
         Task expectedTaskMultipleTags = new TaskBuilder(BOB)
             .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
             .build();

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -9,10 +9,10 @@ import org.junit.Test;
 
 public class ArgumentTokenizerTest {
 
-    private final Prefix unknownPrefix = new Prefix("--u");
-    private final Prefix pSlash = new Prefix("p/");
-    private final Prefix dashT = new Prefix("-t");
-    private final Prefix hatQ = new Prefix("^Q");
+    private final Prefix unknownPrefix = new Prefix("--u", true);
+    private final Prefix pSlash = new Prefix("p/", true);
+    private final Prefix dashT = new Prefix("-t", true);
+    private final Prefix hatQ = new Prefix("^Q", true);
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -184,13 +184,13 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void equalsMethod() {
-        Prefix aaa = new Prefix("aaa");
+        Prefix aaa = new Prefix("aaa", true);
 
         assertEquals(aaa, aaa);
-        assertEquals(aaa, new Prefix("aaa"));
+        assertEquals(aaa, new Prefix("aaa", true));
 
         assertNotEquals(aaa, "aaa");
-        assertNotEquals(aaa, new Prefix("aab"));
+        assertNotEquals(aaa, new Prefix("aab", true));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -86,7 +86,7 @@ public class ArgumentTokenizerTest {
 
     }
 
-    @Test(expected=InputMismatchException.class)
+    @Test(expected = InputMismatchException.class)
     public void tokenize_oneArgumentWithNoRepeats() {
         // No repeated with preamble
         String argsString = "  Some preamble string p/ Argument value  p/ Second Arg p/ Third";
@@ -194,7 +194,7 @@ public class ArgumentTokenizerTest {
         assertArgumentPresent(argMultimap, pSlash, "p/p/p.docx");
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void tokenize_argumentsWithSamePrefixes() {
         String argsString = "p/123 p/\"Hello World\"";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, pSlashSingle);

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -5,14 +5,19 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.InputMismatchException;
+
 import org.junit.Test;
 
 public class ArgumentTokenizerTest {
 
     private final Prefix unknownPrefix = new Prefix("--u", true);
     private final Prefix pSlash = new Prefix("p/", true);
+    private final Prefix pSlashSingle = new Prefix("p/", false);
     private final Prefix dashT = new Prefix("-t", true);
+    private final Prefix dashTSingle = new Prefix("-t", false);
     private final Prefix hatQ = new Prefix("^Q", true);
+    private final Prefix hatQSingle = new Prefix("^Q", false);
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -79,6 +84,13 @@ public class ArgumentTokenizerTest {
         assertPreambleEmpty(argMultimap);
         assertArgumentPresent(argMultimap, pSlash, "Argument value");
 
+    }
+
+    @Test(expected=InputMismatchException.class)
+    public void tokenize_oneArgumentWithNoRepeats() {
+        // No repeated with preamble
+        String argsString = "  Some preamble string p/ Argument value  p/ Second Arg p/ Third";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlashSingle);
     }
 
     @Test
@@ -184,7 +196,6 @@ public class ArgumentTokenizerTest {
 
     @Test(expected=IllegalArgumentException.class)
     public void tokenize_argumentsWithSamePrefixes() {
-        Prefix pSlashSingle = new Prefix("p/", false);
         String argsString = "p/123 p/\"Hello World\"";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, pSlashSingle);
     }
@@ -198,6 +209,7 @@ public class ArgumentTokenizerTest {
 
         assertNotEquals(aaa, "aaa");
         assertNotEquals(aaa, new Prefix("aab", true));
+        assertNotEquals(aaa, new Prefix("aaa", false));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -182,6 +182,13 @@ public class ArgumentTokenizerTest {
         assertArgumentPresent(argMultimap, pSlash, "p/p/p.docx");
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void tokenize_argumentsWithSamePrefixes() {
+        Prefix pSlashSingle = new Prefix("p/", false);
+        String argsString = "p/123 p/\"Hello World\"";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, pSlashSingle);
+    }
+
     @Test
     public void equalsMethod() {
         Prefix aaa = new Prefix("aaa", true);


### PR DESCRIPTION
Reject commands where arguments are duplicated.
Currently, the only command where arguments can duplicate is the tag command.
This PR resolves #147 