### PR TITLE
Filter: Implement matching with any textual and date field

### DIFF
--- a/src/main/java/seedu/address/logic/parser/StringTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/StringTokenizer.java
@@ -195,6 +195,8 @@ public class StringTokenizer {
 
     /**
      * Gets all the tokens from this tokenizer.
+     *
+     * @throws InputMismatchException if there are invalid tokens.
      */
     public List<String> toList() {
         ArrayList<String> items = new ArrayList<>();

--- a/src/main/java/seedu/address/model/util/SetUtil.java
+++ b/src/main/java/seedu/address/model/util/SetUtil.java
@@ -37,8 +37,9 @@ public class SetUtil {
                 }
                 try {
                     return klass.getDeclaredConstructor(String.class).newInstance(token);
-                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
-                    | InvocationTargetException e) {
+                } catch (InvocationTargetException e) {
+                    throw new InvocationTargetWrapperException(e);
+                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException e) {
                     throw new IllegalArgumentException("Class does not support construction from a single string", e);
                 }
             }).collect(Collectors.toSet());
@@ -55,6 +56,22 @@ public class SetUtil {
             }
         } catch (InputMismatchException e) {
             throw new InvalidPredicateTestPhraseException(e);
+        } catch (InvocationTargetWrapperException e) {
+            throw new InvalidPredicateTestPhraseException(e.getCause());
+        }
+    }
+
+    /**
+     * Wrapper class to wrapped the checked InvocationTargetException into an unchecked exception.
+     * It is used to throw the exception through the Stream machinery that is not declared to throw any exception.
+     */
+    private static class InvocationTargetWrapperException extends RuntimeException {
+        public InvocationTargetWrapperException(InvocationTargetException cause) {
+            super(cause);
+        }
+        @Override
+        public InvocationTargetException getCause() {
+            return (InvocationTargetException) super.getCause();
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -219,6 +219,80 @@ public class FilterCommandTest {
     }
 
     @Test
+    public void execute_priorityInvalid_failure() {
+        ensureParseFailure("p:a");
+        ensureParseFailure("p:-1");
+        ensureParseFailure("p:5");
+        ensureParseFailure("p:-10");
+        ensureParseFailure("p:10");
+        ensureParseFailure("p:2.5");
+    }
+
+    @Test
+    public void execute_frequencyExact_success() {
+        FilterCommand command = ensureParseSuccess("f=225");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(FIONA), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_frequencyLower_success() {
+        FilterCommand command = ensureParseSuccess("f<200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_frequencyHigher_success() {
+        FilterCommand command = ensureParseSuccess("f>200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_frequencyConvenience_success() {
+        FilterCommand command = ensureParseSuccess("f:200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_frequencyLongform_success() {
+        FilterCommand command = ensureParseSuccess("frequency:200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_frequencySpaced_success() {
+        FilterCommand command;
+
+        command = ensureParseSuccess("frequency: 200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("frequency : 200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("frequency :200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("frequency  :   200");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_frequencyInvalid_failure() {
+        ensureParseFailure("f:a");
+        ensureParseFailure("f:-1");
+        ensureParseFailure("f:-10");
+        ensureParseFailure("f:2.5");
+    }
+
+    @Test
     public void execute_andOperator_success() {
         FilterCommand command;
 

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -187,6 +187,95 @@ public class FilterCommandTest {
         assertEquals(Arrays.asList(ALICE, CARL, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
     }
 
+    @Test
+    public void execute_parenthesesOr_success() {
+        FilterCommand command;
+
+        command = ensureParseSuccess("due: 2/10/2018 || (n:e && n:o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_paranthesesAnd_success() {
+        FilterCommand command;
+
+        command = ensureParseSuccess("due: 2/10/2018 && (n:e || n:o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("(due: 2/10/2018 || d>1/11/2018) && n:benson");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_implicitAnd_success() {
+        FilterCommand command;
+
+        command = ensureParseSuccess("due: 2/10/2018 (n:e || n:o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("(due: 2/10/2018 || d>1/11/2018) n:benson");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("due: 2/10/2018 || (n:e n:o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_anyMatch_success() {
+        FilterCommand command;
+
+        command = ensureParseSuccess("2/10/2018 & (n:e || n:o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("2/10/2018 &(e | o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("d>1/11/2018 & benson");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("due: 2/10/2018 || (e && o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("2/10/2018 || (e & o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_anyMatchWithImplicitAnd_success() {
+        FilterCommand command;
+
+        command = ensureParseSuccess("2/10/2018 (n:e || n:o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("2/10/2018 (e || o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("d>1/11/2018 benson");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("due: 2/10/2018 || (e o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+
+        command = ensureParseSuccess("2/10/2018 || (e o)");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+    }
+
     /**
      * Throws an assertion error if parsing fails, or else returns the successfully parsed FilterCommand.
      *

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -101,6 +101,20 @@ public class FilterCommandTest {
     }
 
     @Test
+    public void execute_nameMissingQuote_failure() {
+        ensureParseFailure("n:\"abcde");
+        ensureParseFailure("n:abcde\"");
+        ensureParseFailure("n:\'abcde");
+        ensureParseFailure("n:abcde\'");
+    }
+
+    @Test
+    public void execute_nameWrongQuote_failure() {
+        ensureParseFailure("n:\"abcde\'");
+        ensureParseFailure("n:\'abcde\"");
+    }
+
+    @Test
     public void execute_dueExact_success() {
         FilterCommand command = ensureParseSuccess("d=1/10/2018");
         command.execute(model, null);
@@ -136,24 +150,72 @@ public class FilterCommandTest {
     }
 
     @Test
-    public void execute_dueSpaced_success() {
+    public void execute_dueQuotedDouble_success() {
+        FilterCommand command = ensureParseSuccess("due:\"2/10/2018\"");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_dueInvalidDate_failure() {
+        ensureParseFailure("due:abcde");
+        ensureParseFailure("due:ab/c/defg");
+    }
+
+    @Test
+    public void execute_priorityExact_success() {
+        FilterCommand command = ensureParseSuccess("p=2");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(BENSON, FIONA), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_priorityLower_success() {
+        FilterCommand command = ensureParseSuccess("p<2");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(BENSON, CARL, DANIEL, FIONA, GEORGE), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_priorityHigher_success() {
+        FilterCommand command = ensureParseSuccess("p>2");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_priorityConvenience_success() {
+        FilterCommand command = ensureParseSuccess("p:2");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_priorityLongform_success() {
+        FilterCommand command = ensureParseSuccess("priority:2");
+        command.execute(model, null);
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_prioritySpaced_success() {
         FilterCommand command;
 
-        command = ensureParseSuccess("due: 2/10/2018");
+        command = ensureParseSuccess("priority: 2");
         command.execute(model, null);
-        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA), model.getFilteredTaskList());
 
-        command = ensureParseSuccess("due : 2/10/2018");
+        command = ensureParseSuccess("priority : 2");
         command.execute(model, null);
-        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA), model.getFilteredTaskList());
 
-        command = ensureParseSuccess("due :2/10/2018");
+        command = ensureParseSuccess("priority :2");
         command.execute(model, null);
-        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA), model.getFilteredTaskList());
 
-        command = ensureParseSuccess("due  :   2/10/2018");
+        command = ensureParseSuccess("priority  :   2");
         command.execute(model, null);
-        assertEquals(Arrays.asList(ALICE, ELLE, FIONA, GEORGE), model.getFilteredTaskList());
+        assertEquals(Arrays.asList(ALICE, BENSON, ELLE, FIONA), model.getFilteredTaskList());
     }
 
     @Test
@@ -287,6 +349,20 @@ public class FilterCommandTest {
             return new FilterCommandParser().parse(predicate);
         } catch (ParseException e) {
             throw new AssertionError("ParseException was thrown.", e);
+        }
+    }
+
+    /**
+     * Throws an assertion error if parsing succeeds, or else returns normally.
+     *
+     * @param predicate The string to parse as a predicate.
+     */
+    private void ensureParseFailure(String predicate) {
+        try {
+            new FilterCommandParser().parse(predicate);
+            throw new AssertionError("ParseException was expected but not thrown.");
+        } catch (ParseException e) {
+            // don't do anything
         }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -43,6 +43,16 @@ public class FilterCommandParserTest {
         assertParseSuccess(parser, "n<\"Hello World\"");
         assertParseSuccess(parser, "n:Test");
 
+        assertParseSuccess(parser, "p>1");
+        assertParseSuccess(parser, "p:1");
+        assertParseSuccess(parser, "p<1");
+        assertParseSuccess(parser, "p=1");
+        assertParseSuccess(parser, "p:0");
+        assertParseSuccess(parser, "p:2");
+        assertParseSuccess(parser, "p:3");
+        assertParseSuccess(parser, "p:4");
+        assertParseSuccess(parser, "p:\"3\"");
+
         assertParseSuccess(parser, "f>1");
         assertParseSuccess(parser, "f:1");
         assertParseSuccess(parser, "f<1");

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -141,17 +141,14 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "d<");
         assertParseThrowsException(parser, "d=");
         assertParseThrowsException(parser, "d>");
-        assertParseThrowsException(parser, "d");
         assertParseThrowsException(parser, "p:5");
         assertParseThrowsException(parser, "p:b");
         assertParseThrowsException(parser, "=");
         assertParseThrowsException(parser, ":");
-        assertParseThrowsException(parser, "-");
         assertParseThrowsException(parser, "test=test");
         assertParseThrowsException(parser, "=test");
         assertParseThrowsException(parser, "name>");
         assertParseThrowsException(parser, "name<");
-        assertParseThrowsException(parser, "name~");
         assertParseThrowsException(parser, "name:");
         assertParseThrowsException(parser, "t:\"CS2101,CS2103");
         assertParseThrowsException(parser, "(t:\"CS2101,CS2103");

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -140,6 +140,33 @@ public class FilterCommandParserTest {
     }
 
     @Test
+    public void parse_anyField_doesNotThrow() {
+        assertParseSuccess(parser, "Testp");
+        assertParseSuccess(parser, "1/10/2018");
+        assertParseSuccess(parser, "1/10/2018 Testp");
+        assertParseSuccess(parser, "1/10/2018 Testp htrhrth");
+        assertParseSuccess(parser, "1/10/2018 \"Testp htrhrth\"");
+        assertParseSuccess(parser, "Testp htrhrth 1/10/2018");
+        assertParseSuccess(parser, "Testp 1/10/2018");
+        assertParseSuccess(parser, "Testp   1/10/2018");
+        assertParseSuccess(parser, "Testp && 1/10/2018");
+        assertParseSuccess(parser, "Testp&&1/10/2018");
+        assertParseSuccess(parser, "Testp!1/10/2018");
+        assertParseSuccess(parser, "Testp d:1/10/2018");
+        assertParseSuccess(parser, "n:Testp 1/10/2018");
+        assertParseSuccess(parser, "Testp|d:1/10/2018");
+        assertParseSuccess(parser, "Testp | d:1/10/2018");
+        assertParseSuccess(parser, "Testp | d : 1/10/2018");
+        assertParseSuccess(parser, "Testp || 1/10/2018");
+        assertParseSuccess(parser, "n:Testp | 1/10/2018");
+        assertParseSuccess(parser, "n:Testp|1/10/2018");
+        assertParseSuccess(parser, "Testp|(!n:Hello||!n:World)");
+        assertParseSuccess(parser, "Testp(!n:Hello||!n:World)");
+        assertParseSuccess(parser, "(!n:Hello||!n:World)|Testp");
+        assertParseSuccess(parser, "(!n:Hello||!n:World)Testp");
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseThrowsException(parser, "d<\"1/10/2018");
         assertParseThrowsException(parser, "d<1/10/2018\"");
@@ -177,6 +204,7 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "(!n:Hello|| ||!n:World)");
         assertParseThrowsException(parser, "(!n:Hello||||!n:World)");
         assertParseThrowsException(parser, "(!n:Hello|||!n:World)");
+        assertParseThrowsException(parser, "n:Hello!");
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -43,15 +43,15 @@ public class FilterCommandParserTest {
         assertParseSuccess(parser, "n<\"Hello World\"");
         assertParseSuccess(parser, "n:Test");
 
-        assertParseSuccess(parser, "p>1");
-        assertParseSuccess(parser, "p:1");
-        assertParseSuccess(parser, "p<1");
-        assertParseSuccess(parser, "p=1");
-        assertParseSuccess(parser, "p:0");
-        assertParseSuccess(parser, "p:2");
-        assertParseSuccess(parser, "p:3");
-        assertParseSuccess(parser, "p:4");
-        assertParseSuccess(parser, "p:\"3\"");
+        assertParseSuccess(parser, "f>1");
+        assertParseSuccess(parser, "f:1");
+        assertParseSuccess(parser, "f<1");
+        assertParseSuccess(parser, "f=1");
+        assertParseSuccess(parser, "f:0");
+        assertParseSuccess(parser, "f:2");
+        assertParseSuccess(parser, "f:3");
+        assertParseSuccess(parser, "f:4");
+        assertParseSuccess(parser, "f:\"3\"");
 
         assertParseSuccess(parser, "t:CS2101,CS2103");
         assertParseSuccess(parser, "t:CS2101");
@@ -143,6 +143,8 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "d>");
         assertParseThrowsException(parser, "p:5");
         assertParseThrowsException(parser, "p:b");
+        assertParseThrowsException(parser, "f:b");
+        assertParseThrowsException(parser, "f:teh");
         assertParseThrowsException(parser, "=");
         assertParseThrowsException(parser, ":");
         assertParseThrowsException(parser, "test=test");

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -157,6 +157,7 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "t:CS2101,CS2103 && ");
         assertParseThrowsException(parser, "t:CS2101,CS2103 && )");
         assertParseThrowsException(parser, "t:CS2101,CS2103 && n:Hello)");
+        assertParseThrowsException(parser, "t:\"1/2/3\"");
         assertParseThrowsException(parser, "(");
         assertParseThrowsException(parser, ")");
         assertParseThrowsException(parser, "&& n:Hello");

--- a/src/test/java/seedu/address/logic/parser/StringTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/StringTokenizerTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.InputMismatchException;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
@@ -56,6 +57,8 @@ public class StringTokenizerTest {
         assertEquals(tokenizer.nextPattern(Pattern.compile("!")), "!");
         assertEquals(tokenizer.nextString(), "Test Test2");
         assertFalse(tokenizer.hasNextToken());
+        assertThrows(NoSuchElementException.class, () -> tokenizer.nextMatcher(Pattern.compile("[a-z&&[^w]]+")));
+        assertThrows(NoSuchElementException.class, () -> tokenizer.nextPattern(Pattern.compile("[a-z&&[^w]]+")));
     }
 
     @Test


### PR DESCRIPTION
When the filter field and filter operator (':', '<', '>', '=') are omitted, the test phrase is matched against the name, deadline, and tags fields.  Priority and frequency are not matched as they often cause many tasks to match, and this is usually not intended (and annoying) to the user.  The convenience operator is used for matching.

Tests will come in a later commit.

This will resolve #158.