### PR TITLE
DeveloperGuide: Number all sections

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -3,7 +3,9 @@
 :toc:
 :toc-title:
 :toc-placement: preamble
+:toclevels: 3
 :sectnums:
+:sectnumlevels: 6
 :imagesDir: images
 :stylesDir: stylesheets
 :xrefstyle: full


### PR DESCRIPTION
Give sections numberings until depth 6 (was 3), and display up to depth 4 (was 3) in table of contents.

@ranaldmiao @sijie123 @sidhant007 @kc97ble Please check that your respective implementations section still look alright.