### PR TITLE
Add file parse error message to catch cases where import file is incompatible.

### DIFF
--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -17,13 +17,14 @@ import seedu.address.model.UserPrefs;
  */
 public interface Storage extends ImportExportStorage, TaskCollectionStorage, UserPrefsStorage {
 
-    String MESSAGE_WRITE_FILE_EXISTS_ERROR = "Save file already exists."
+    String MESSAGE_WRITE_FILE_EXISTS_ERROR = "Save file at %s already exists."
             + " Please rename or force export with the r/overwrite flag.";
     String MESSAGE_WRITE_FILE_NO_PERMISSION_ERROR = "Cannot write to the file at %s. "
             + " Please check your file permission settings.";
     String MESSAGE_READ_FILE_MISSING_ERROR = "File does not exist."
             + " Double check your import file.";
-    String MESSAGE_READ_FILE_SAME_ERROR = "Cannot import from the current working file.";
+    String MESSAGE_READ_FILE_PARSE_ERROR = "Failed to read file at %s."
+            + " The file format is incompatible with Deadine Manager.";
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -27,7 +27,8 @@ public class ExportCommandTest {
 
     @Test
     public void execute_exportOnExistingFile_exceptionThrown() {
-        IOException expectedException = new IOException(StorageManager.MESSAGE_WRITE_FILE_EXISTS_ERROR);
+        IOException expectedException = new IOException(
+            String.format(StorageManager.MESSAGE_WRITE_FILE_EXISTS_ERROR, defaultFile));
         ExportCommand testCommand = new ExportCommand(defaultFile, false);
         ModelStubWithExportTaskCollection modelStub = new ModelStubWithExportTaskCollection(defaultFile, testCommand);
         assertCommandFailure(testCommand, modelStub, commandHistory,
@@ -78,7 +79,8 @@ public class ExportCommandTest {
                 return;
             }
             if (filename.equals(this.filename)) {
-                Exception fileExistException = new IOException(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR);
+                Exception fileExistException = new IOException(
+                    String.format(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR, this.filename));
                 testCommand.handleImportExportExceptionEvent(new ImportExportExceptionEvent(fileExistException));
                 return;
             }

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -71,11 +71,6 @@ public class ImportCommandTest {
                 //No error.
                 return;
             }
-            if (filename.equals(this.filename)) {
-                Exception fileRepeatException = new IOException(Storage.MESSAGE_READ_FILE_SAME_ERROR);
-                testCommand.handleImportExportExceptionEvent(new ImportExportExceptionEvent(fileRepeatException));
-                return;
-            }
             if (filename.equals(doesNotExistPath)) {
                 Exception fileMissingException = new IOException(Storage.MESSAGE_READ_FILE_MISSING_ERROR);
                 testCommand.handleImportExportExceptionEvent(new ImportExportExceptionEvent(fileMissingException));

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -92,7 +92,8 @@ public class StorageManagerTest {
         // Exporting with file name equal to the working file should throw IllegalValueException.
         TaskCollection original = getTypicalTaskCollections();
         storageManager.saveTaskCollection(original);
-        Assert.assertThrows(IOException.class, Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR, () ->
+        Assert.assertThrows(IOException.class,
+            String.format(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR, storageManager.getTaskCollectionFilePath()), () ->
             storageManager.exportTaskCollection(original, storageManager.getTaskCollectionFilePath(), false));
     }
 
@@ -158,7 +159,8 @@ public class StorageManagerTest {
         ReadOnlyTaskCollection retrieved = storageManager.importTaskCollection(getTempFilePath("dummyExport"))
                                                          .get();
         assertEquals(original, new TaskCollection(retrieved));
-        Assert.assertThrows(IOException.class, Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR, () ->
+        Assert.assertThrows(IOException.class,
+            String.format(Storage.MESSAGE_WRITE_FILE_EXISTS_ERROR, getTempFilePath("dummyExport")), () ->
             storageManager.exportTaskCollection(original, getTempFilePath("dummyExport"), false));
 
         try {

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskCollections;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -16,7 +18,6 @@ import org.junit.rules.TemporaryFolder;
 
 import seedu.address.commons.events.model.TaskCollectionChangedEvent;
 import seedu.address.commons.events.storage.DataSavingExceptionEvent;
-import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.model.ReadOnlyTaskCollection;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.UserPrefs;
@@ -123,7 +124,6 @@ public class StorageManagerTest {
     public void overwriteExportOnUnwritableFile_exceptionThrown() throws IOException {
         // Exporting with file name "." should throw as directory is unwritable.
         TaskCollection original = getTypicalTaskCollections();
-        //storageManager.saveTaskCollection(original);
         Assert.assertThrows(IOException.class,
             String.format(Storage.MESSAGE_WRITE_FILE_NO_PERMISSION_ERROR, getTempFilePath(".")), () ->
             storageManager.exportTaskCollection(original, getTempFilePath("."), false));
@@ -136,7 +136,28 @@ public class StorageManagerTest {
     }
 
     @Test
-    public void importExistingFile_success() throws DataConversionException {
+    public void importUnreadableFile_exceptionThrown() throws IOException {
+        String rubbishFile = "rubbishFile";
+        createTempFile(rubbishFile);
+        Assert.assertThrows(IOException.class,
+            String.format(Storage.MESSAGE_READ_FILE_PARSE_ERROR, getTempFilePath(rubbishFile)), () ->
+                storageManager.importTaskCollection(getTempFilePath(rubbishFile)));
+        removeTempFile(rubbishFile);
+    }
+
+    private void removeTempFile(String filename) {
+        File delete = new File(getTempFilePath(filename).toString());
+        delete.delete();
+    }
+
+    private void createTempFile(String filename) throws IOException {
+        FileWriter fileWriter = new FileWriter(getTempFilePath(filename).toString());
+        fileWriter.write("garbage");
+        fileWriter.close();
+    }
+
+    @Test
+    public void importExistingFile_success() {
         TaskCollection original = getTypicalTaskCollections();
         try {
             storageManager.saveTaskCollection(original);


### PR DESCRIPTION
Additionally, modify MESSAGE_WRITE_FILE_EXISTS_ERROR to make error more informative.