### PR TITLE
Filter: Make any-match expression only match [A-Za-z0-9\_\-\/]

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -164,10 +164,11 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         // test<blah
         // name>"hello world"
 
-        final Predicate<Character> operatorCharacterPredicate = ch
-            -> ch == '=' || ch == '<' || ch == '>' || ch == ':';
-
-        final Predicate<Character> allowedKeyCharacterPredicate = operatorCharacterPredicate.negate();
+        // note: '/' is necessary for dates
+        final Predicate<Character> allowedKeyCharacterPredicate = ch -> (ch >= 'A' && ch <= 'Z')
+                                                                     || (ch >= 'a' && ch <= 'z')
+                                                                     || (ch >= '0' && ch <= '9')
+                                                                     || ch == '_' || ch == '-' || ch == '/';
 
         try {
             BooleanExpressionParser<Task> expressionParser =


### PR DESCRIPTION
This makes it less likely for filter to silently succeed when users to inadvertently specify a wrong operator.

This will resolve #175.