### PR TITLE
Filter: Add full operator support for set-based fields

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -75,6 +75,19 @@ public class StringUtil {
     }
 
     /**
+     * Like String.equals, but ignoring case.
+     *
+     * @param phrase1 cannot be null
+     * @param phrase2 cannot be null
+     */
+    public static boolean equalsIgnoreCase(String phrase1, String phrase2) {
+        requireNonNull(phrase1);
+        requireNonNull(phrase2);
+
+        return phrase1.toLowerCase().equals(phrase2.toLowerCase());
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -27,39 +27,89 @@ import seedu.address.model.util.SetUtil;
 public class FilterCommandParser implements Parser<FilterCommand> {
 
     private static final String MESSAGE_INVALID_KEY_FORMAT = "Invalid key: %1$s";
+    private static final String MESSAGE_INVALID_KEY_DOUBLE_OPERATOR_FORMAT =
+        "Invalid key for set-based filter: %1$s";
     private static final String MESSAGE_INVALID_OPERATOR_FORMAT = "Invalid filter operator: %1$s";
     private static final String MESSAGE_INVALID_TESTPHRASE_FORMAT = "Invalid filter test value: %1$s";
     private static final String MESSAGE_INVALID_GENERAL_PREDICATE_FORMAT = "Invalid filter: %1$s";
 
+    private static final String KEY_NAME_SHORT = "n";
+    private static final String KEY_NAME_LONG = "name";
+    private static final String KEY_DEADLINE_SHORT = "d";
+    private static final String KEY_DEADLINE_LONG = "due";
+    private static final String KEY_PRIORITY_SHORT = "p";
+    private static final String KEY_PRIORITY_LONG = "priority";
+    private static final String KEY_FREQUENCY_SHORT = "f";
+    private static final String KEY_FREQUENCY_LONG = "frequency";
+    private static final String KEY_TAG_SHORT = "t";
+    private static final String KEY_TAG_LONG = "tag";
+
     private static final Predicate<Task> ALWAYS_FALSE = task -> false;
 
+
+    // used to match things like:
+    // due=1/10/2018
+    // test<blah
+    // name>"hello world"
+    // note: '/' is necessary for dates, ',' is necessary for tags
+    private static final Predicate<Character> ALLOWED_UNQUOTED_CHARACTER_PREDICATE =
+        ch -> (ch >= 'A' && ch <= 'Z')
+        || (ch >= 'a' && ch <= 'z')
+        || (ch >= '0' && ch <= '9')
+        || ch == '_'
+        || ch == '-'
+        || ch == '/'
+        || ch == ',';
+
+    private static final Predicate<Character> ALLOWED_KEY_CHARACTER_PREDICATE =
+        ch -> (ch >= 'A' && ch <= 'Z')
+        || (ch >= 'a' && ch <= 'z');
+
+    private static final Pattern FILTER_OPERATOR_PATTERN = Pattern.compile("[\\=\\<\\>\\:]");
+
+    /**
+     * Creates a predicate that filters by name.
+     */
     private static Predicate<Task> createNamePredicate(FilterOperator operator, String testPhrase)
         throws InvalidPredicateOperatorException {
         Predicate<Name> namePredicate = Name.makeFilter(operator, testPhrase);
         return task -> namePredicate.test(task.getName());
     }
 
+    /**
+     * Creates a predicate that filters by deadline.
+     */
     private static Predicate<Task> createDeadlinePredicate(FilterOperator operator, String testPhrase)
-        throws InvalidPredicateException {
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
         Predicate<Deadline> deadlinePredicate = Deadline.makeFilter(operator, testPhrase);
         return task -> deadlinePredicate.test(task.getDeadline());
     }
 
+    /**
+     * Creates a predicate that filters by priority.
+     */
     private static Predicate<Task> createPriorityPredicate(FilterOperator operator, String testPhrase)
-        throws InvalidPredicateException {
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
         Predicate<Priority> priorityPredicate = Priority.makeFilter(operator, testPhrase);
         return task -> priorityPredicate.test(task.getPriority());
     }
 
+    /**
+     * Creates a predicate that filters by frequency.
+     */
     private static Predicate<Task> createFrequencyPredicate(FilterOperator operator, String testPhrase)
-        throws InvalidPredicateException {
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
         Predicate<Frequency> frequencyPredicate = Frequency.makeFilter(operator, testPhrase);
         return task -> frequencyPredicate.test(task.getFrequency());
     }
 
-    private static Predicate<Task> createTagsPredicate(FilterOperator operator, String testPhrase)
-        throws InvalidPredicateException {
-        Predicate<Set<Tag>> tagsPredicate = SetUtil.makeFilter(Tag.class, operator, testPhrase);
+    /**
+     * Creates a predicate that filters by tags.
+     */
+    private static Predicate<Task> createTagsPredicate(FilterOperator setOperator, FilterOperator fieldOperator,
+                                                       String testPhrase)
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
+        Predicate<Set<Tag>> tagsPredicate = SetUtil.makeFilter(Tag.class, setOperator, fieldOperator, testPhrase);
         return task -> tagsPredicate.test(task.getTags());
     }
 
@@ -75,6 +125,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      * Invokes the supplier, and converts an InvalidPredicateException to a predicate that always returns false.
      *
      * @param supplier The supplier that either produces a predicate or throws an exception.
+     *
      * @return On success returns the predicate that is returned by the supplier,
      *         on failure returns a predicate that is always false.
      */
@@ -92,33 +143,29 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      * @param key        The key that refers to the specific field in a task.
      * @param operator   The filter operator.
      * @param testPhrase The test phrase to compare with the specific field of each task.
+     *
      * @return The predicate that is created.
      */
     private static Predicate<Task> createPredicate(String key, FilterOperator operator, String testPhrase)
-        throws ParseException, InvalidPredicateException {
+        throws ParseException {
 
         try {
             switch (key) {
-            case "n": // fallthrough
-            case "name": {
+            case KEY_NAME_SHORT: // fallthrough
+            case KEY_NAME_LONG:
                 return createNamePredicate(operator, testPhrase);
-            }
-            case "d": // fallthrough
-            case "due": {
+            case KEY_DEADLINE_SHORT: // fallthrough
+            case KEY_DEADLINE_LONG:
                 return createDeadlinePredicate(operator, testPhrase);
-            }
-            case "p": // fallthrough
-            case "priority": {
+            case KEY_PRIORITY_SHORT: // fallthrough
+            case KEY_PRIORITY_LONG:
                 return createPriorityPredicate(operator, testPhrase);
-            }
-            case "f": // fallthrough
-            case "frequency": {
+            case KEY_FREQUENCY_SHORT: // fallthrough
+            case KEY_FREQUENCY_LONG:
                 return createFrequencyPredicate(operator, testPhrase);
-            }
-            case "t": // fallthrough
-            case "tag": {
-                return createTagsPredicate(operator, testPhrase);
-            }
+            case KEY_TAG_SHORT: // fallthrough
+            case KEY_TAG_LONG:
+                return createTagsPredicate(FilterOperator.CONVENIENCE, operator, testPhrase);
             default:
                 throw new ParseException(String.format(MESSAGE_INVALID_KEY_FORMAT, key));
             }
@@ -130,26 +177,89 @@ public class FilterCommandParser implements Parser<FilterCommand> {
     }
 
     /**
+     * Creates a predicate from the specified key, two operators, and test phrase.
+     * This overload is used for filters of set-based fields (e.g. tags and attachments.
+     * The set operator and the field-specific operator can be specified independently.
+     *
+     * @param key           The key that refers to the specific field in a task.
+     * @param setOperator   The set filter operator.
+     * @param fieldOperator The field-specific filter operator.
+     * @param testPhrase     The test phrase to compare with the specific field of each task.
+     *
+     * @return The predicate that is created.
+     */
+    private static Predicate<Task> createPredicate(String key,
+                                                   FilterOperator setOperator,
+                                                   FilterOperator fieldOperator,
+                                                   String testPhrase)
+        throws ParseException {
+
+        try {
+            switch (key) {
+            case KEY_TAG_SHORT: // fallthrough
+            case KEY_TAG_LONG:
+                return createTagsPredicate(setOperator, fieldOperator, testPhrase);
+            default:
+                if (isValidKey(key)) {
+                    throw new ParseException(String.format(MESSAGE_INVALID_KEY_DOUBLE_OPERATOR_FORMAT, key));
+                } else {
+                    throw new ParseException(String.format(MESSAGE_INVALID_KEY_FORMAT, key));
+                }
+            }
+        } catch (InvalidPredicateOperatorException e) {
+            throw new ParseException(MESSAGE_INVALID_OPERATOR_FORMAT, e);
+        } catch (InvalidPredicateTestPhraseException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_TESTPHRASE_FORMAT, testPhrase), e);
+        }
+    }
+
+    /**
+     * Checks if the given string represents a valid field identifier.
+     *
+     * @param key The field identifier to check.
+     *
+     * @return True if the field identifier is valid, false otherwise.
+     */
+    private static boolean isValidKey(String key) {
+        switch (key) {
+        case KEY_NAME_SHORT:
+        case KEY_NAME_LONG:
+        case KEY_DEADLINE_SHORT:
+        case KEY_DEADLINE_LONG:
+        case KEY_PRIORITY_SHORT:
+        case KEY_PRIORITY_LONG:
+        case KEY_FREQUENCY_SHORT:
+        case KEY_FREQUENCY_LONG:
+        case KEY_TAG_SHORT:
+        case KEY_TAG_LONG:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
      * Creates a predicate matches any textual or date field in a task, using the convenience operator.
      * It does not match numeric fields because they clutter the results and are usually not intended by the user.
      *
      * @param testPhrase The test phrase to compare with the specific field of each task.
      */
-    private static Predicate<Task> createPredicateAny(String testPhrase)
-        throws InvalidPredicateException {
+    private static Predicate<Task> createPredicateAny(String testPhrase) {
         return ALWAYS_FALSE
             .or(silencePredicateException(() -> createNamePredicate(FilterOperator.CONVENIENCE, testPhrase)))
             .or(silencePredicateException(() -> createDeadlinePredicate(FilterOperator.CONVENIENCE, testPhrase)))
-            .or(silencePredicateException(() -> createTagsPredicate(FilterOperator.CONVENIENCE, testPhrase)));
+            .or(silencePredicateException(() -> createTagsPredicate(
+                FilterOperator.CONVENIENCE, FilterOperator.CONVENIENCE, testPhrase)));
     }
-
 
 
     /**
      * Parses the given {@code String} of arguments in the context of the FilterCommand and returns an
      * FilterCommand object for execution.
      *
-     * @throws ParseException if the user input does not conform the expected format
+     * @param args The filter expression to parse.
+     *
+     * @throws ParseException if the user input does not conform the expected format.
      */
     @Override
     public FilterCommand parse(String args) throws ParseException {
@@ -159,52 +269,14 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
-        // pattern that matches things like:
-        // due=1/10/2018
-        // test<blah
-        // name>"hello world"
-
-        // note: '/' is necessary for dates, ',' is necessary for tags
-        final Predicate<Character> allowedUnquotedCharacterPredicate = ch -> (ch >= 'A' && ch <= 'Z')
-                                                                     || (ch >= 'a' && ch <= 'z')
-                                                                     || (ch >= '0' && ch <= '9')
-                                                                     || ch == '_'
-                                                                     || ch == '-'
-                                                                     || ch == '/'
-                                                                     || ch == ',';
-
-        final Predicate<Character> allowedKeyCharacterPredicate = ch -> (ch >= 'A' && ch <= 'Z')
-                                                                || (ch >= 'a' && ch <= 'z');
-
         try {
             BooleanExpressionParser<Task> expressionParser =
                 new BooleanExpressionParser<>((tokenizer, reservedCharPredicate) -> {
                     final Predicate<Character> effectiveUnquotedCharacterPredicate = reservedCharPredicate.negate()
-                        .and(allowedUnquotedCharacterPredicate);
+                        .and(ALLOWED_UNQUOTED_CHARACTER_PREDICATE);
 
-                    int tokenizerLocation = tokenizer.getLocation(); // get the location in case we need to rewind
-                    final String key = tokenizer.tryNextString(allowedKeyCharacterPredicate);
-                    String opString;
-                    if (key != null && tokenizer.hasNextToken()
-                        && (opString = tokenizer.tryNextPattern(Pattern.compile("[\\=\\<\\>\\:]"))) != null) {
-                        final FilterOperator operator = FilterOperator.parse(opString);
-                        final String testPhrase = tokenizer.nextString(effectiveUnquotedCharacterPredicate);
-                        try {
-                            return createPredicate(key, operator, testPhrase);
-                        } catch (InvalidPredicateException e) { // note: this catch block can never happen
-                            throw new ParseException(String.format(MESSAGE_INVALID_GENERAL_PREDICATE_FORMAT, key + ' '
-                                + opString + ' ' + testPhrase), e);
-                        }
-                    } else {
-                        tokenizer.setLocation(tokenizerLocation); // rewind the tokenizer
-                        final String testPhrase = tokenizer.nextString(effectiveUnquotedCharacterPredicate);
-                        try {
-                            return createPredicateAny(testPhrase);
-                        } catch (InvalidPredicateException e) { // note: this catch block can never happen
-                            throw new ParseException(
-                                String.format(MESSAGE_INVALID_GENERAL_PREDICATE_FORMAT, testPhrase), e);
-                        }
-                    }
+                    return createFilterUnit(tokenizer, effectiveUnquotedCharacterPredicate,
+                        ALLOWED_KEY_CHARACTER_PREDICATE);
                 });
             Predicate<Task> predicate = expressionParser.parse(args);
 
@@ -214,6 +286,45 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             throw new ParseException("Invalid filter expression: " + e.getMessage(), e);
         }
 
+    }
+
+
+    /**
+     * Reads and returns a predicate from the given string tokenizer.
+     *
+     * @param tokenizer                           The string tokenizer.
+     * @param effectiveUnquotedCharacterPredicate A predicate that specifies the allowable characters
+     *                                            for unquoted test phrases.
+     * @param allowedKeyCharacterPredicate        A predicate that specifies the allowable characters
+     *                                            for filter field identifiers (i.e. keys).
+     *
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    private static Predicate<Task> createFilterUnit(StringTokenizer tokenizer,
+                                                    Predicate<Character> effectiveUnquotedCharacterPredicate,
+                                                    Predicate<Character> allowedKeyCharacterPredicate)
+        throws ParseException {
+        int tokenizerLocation = tokenizer.getLocation(); // get the location in case we need to rewind
+        final String key = tokenizer.tryNextString(allowedKeyCharacterPredicate);
+        String opString;
+        if (key != null && tokenizer.hasNextToken()
+            && (opString = tokenizer.tryNextPattern(FILTER_OPERATOR_PATTERN)) != null) {
+            final FilterOperator operator = FilterOperator.parse(opString);
+            String opString2 = tokenizer.tryNextPattern(FILTER_OPERATOR_PATTERN); // could be null
+            final String testPhrase = tokenizer.nextString(effectiveUnquotedCharacterPredicate);
+            if (opString2 == null) {
+                // has only one filter operator
+                return createPredicate(key, operator, testPhrase);
+            } else {
+                // has two filter operators
+                final FilterOperator operator2 = FilterOperator.parse(opString2);
+                return createPredicate(key, operator, operator2, testPhrase);
+            }
+        } else {
+            tokenizer.setLocation(tokenizerLocation); // rewind the tokenizer
+            final String testPhrase = tokenizer.nextString(effectiveUnquotedCharacterPredicate);
+            return createPredicateAny(testPhrase);
+        }
     }
 
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -71,7 +71,7 @@ public class Tag {
         }
         switch (operator) {
         case EQUAL:
-            return tag -> tag.tagName.equals(testPhrase);
+            return tag -> StringUtil.equalsIgnoreCase(tag.tagName, testPhrase);
         case LESS:
             return tag -> StringUtil.containsFragmentIgnoreCase(testPhrase, tag.tagName);
         case CONVENIENCE: // convenience operator, works the same as ">"

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -3,6 +3,13 @@ package seedu.address.model.tag;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.task.FilterOperator;
+import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
+import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
+
 /**
  * Represents a Tag in the deadline manager. Guarantees: immutable; name is valid as declared in {@link
  * #isValidTagName(String)}
@@ -49,6 +56,30 @@ public class Tag {
      */
     public String toString() {
         return '[' + tagName + ']';
+    }
+
+    /**
+     * Constructs a predicate from the given operator and test phrase.
+     *
+     * @param operator   The operator for this predicate.
+     * @param testPhrase The test phrase for this predicate.
+     */
+    public static Predicate<Tag> makeFilter(FilterOperator operator, String testPhrase)
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
+        if (!isValidTagName(testPhrase)) {
+            throw new InvalidPredicateTestPhraseException();
+        }
+        switch (operator) {
+        case EQUAL:
+            return tag -> tag.tagName.equals(testPhrase);
+        case LESS:
+            return tag -> StringUtil.containsFragmentIgnoreCase(testPhrase, tag.tagName);
+        case CONVENIENCE: // convenience operator, works the same as ">"
+        case GREATER:
+            return tag -> StringUtil.containsFragmentIgnoreCase(tag.tagName, testPhrase);
+        default:
+            throw new InvalidPredicateOperatorException();
+        }
     }
 
 }

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -10,7 +10,6 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.function.Predicate;
 
-import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
 import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
 

--- a/src/main/java/seedu/address/model/task/Deadline.java
+++ b/src/main/java/seedu/address/model/task/Deadline.java
@@ -74,7 +74,7 @@ public class Deadline implements Comparable<Deadline> {
      * @param testPhrase The test phrase for this predicate.
      */
     public static Predicate<Deadline> makeFilter(FilterOperator operator, String testPhrase)
-            throws InvalidPredicateException {
+            throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
         Deadline testDeadline;
         try {
             testDeadline = new Deadline(testPhrase);

--- a/src/main/java/seedu/address/model/task/Frequency.java
+++ b/src/main/java/seedu/address/model/task/Frequency.java
@@ -66,7 +66,7 @@ public class Frequency implements Comparable<Frequency> {
      * @param testPhrase The test phrase for this predicate.
      */
     public static Predicate<Frequency> makeFilter(FilterOperator operator, String testPhrase)
-        throws InvalidPredicateException {
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
         Frequency tmpFrequency;
         try {
             tmpFrequency = new Frequency(testPhrase);

--- a/src/main/java/seedu/address/model/task/Frequency.java
+++ b/src/main/java/seedu/address/model/task/Frequency.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.function.Predicate;
 
-import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
 import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
 

--- a/src/main/java/seedu/address/model/task/Name.java
+++ b/src/main/java/seedu/address/model/task/Name.java
@@ -53,7 +53,7 @@ public class Name implements Comparable<Name> {
             throws InvalidPredicateOperatorException {
         switch (operator) {
         case EQUAL:
-            return name -> name.value.equals(testPhrase);
+            return name -> StringUtil.equalsIgnoreCase(name.value, testPhrase);
         case LESS:
             return name -> StringUtil.containsFragmentIgnoreCase(testPhrase, name.value);
         case CONVENIENCE: // convenience operator, works the same as ">"

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.function.Predicate;
 
-import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
 import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
 

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -60,7 +60,7 @@ public class Priority implements Comparable<Priority> {
      * @param testPhrase The test phrase for this predicate.
      */
     public static Predicate<Priority> makeFilter(FilterOperator operator, String testPhrase)
-        throws InvalidPredicateException {
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException {
         Priority tmpPriority;
         try {
             tmpPriority = new Priority(testPhrase);

--- a/src/main/java/seedu/address/model/util/SetUtil.java
+++ b/src/main/java/seedu/address/model/util/SetUtil.java
@@ -1,14 +1,16 @@
 package seedu.address.model.util;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.InputMismatchException;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.parser.StringTokenizer;
 import seedu.address.model.task.FilterOperator;
-import seedu.address.model.task.exceptions.InvalidPredicateException;
 import seedu.address.model.task.exceptions.InvalidPredicateOperatorException;
 import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
 
@@ -18,60 +20,115 @@ import seedu.address.model.task.exceptions.InvalidPredicateTestPhraseException;
  */
 public class SetUtil {
     /**
-     * Constructs a predicate from the given operator and test phrase.
+     * Constructs a predicate from the given set operator, given field operator and test phrase.
      * Test phrase should be a comma-separated list of values.
      *
-     * @param klass      The class that this filter is being made for.
-     * @param operator   The operator for this predicate.
-     * @param testPhrase The test phrase for this predicate.
+     * @param klass         The class that this filter is being made for.
+     * @param setOperator   The set operator for this predicate.
+     * @param fieldOperator The set operator for this predicate.
+     * @param testPhrase    The test phrase for this predicate.
+     *
+     * @return The predicate that is constructed.
      */
-    public static <T> Predicate<Set<T>> makeFilter(Class<T> klass, FilterOperator operator, String testPhrase)
-        throws InvalidPredicateException {
+    public static <T> Predicate<Set<T>> makeFilter(Class<T> klass, FilterOperator setOperator,
+                                                   FilterOperator fieldOperator, String testPhrase)
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException, IllegalArgumentException {
+        assert (testPhrase != null);
+        assert (fieldOperator != null);
+        assert (setOperator != null);
         try {
-            // comma-separated quotable tokenizer
-            StringTokenizer tokenizer = new StringTokenizer(testPhrase,
-                ch -> ch == ',', ch -> ch == '\'' || ch == '\"');
-            Set<T> items = tokenizer.toList().stream().map(String::trim).map(token -> {
-                if (token.isEmpty()) {
-                    throw new IllegalArgumentException("Tag cannot be empty");
-                }
-                try {
-                    return klass.getDeclaredConstructor(String.class).newInstance(token);
-                } catch (InvocationTargetException e) {
-                    throw new InvocationTargetWrapperException(e);
-                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException e) {
-                    throw new IllegalArgumentException("Class does not support construction from a single string", e);
-                }
-            }).collect(Collectors.toSet());
-            switch (operator) {
+            List<Predicate<T>> predicates = parseTestPhrase(klass, fieldOperator, testPhrase);
+
+            final Predicate<Set<T>> lessPredicate = set -> set.stream().allMatch(item -> predicates.stream()
+                .anyMatch(predicate -> predicate.test(item)));
+            final Predicate<Set<T>> greaterPredicate = set -> predicates.stream()
+                .allMatch(predicate -> set.stream().anyMatch(predicate));
+
+            switch (setOperator) {
             case EQUAL:
-                return set -> set.equals(items);
+                return lessPredicate.and(greaterPredicate);
             case LESS:
-                return set -> set.stream().allMatch(item -> items.contains(item));
+                return lessPredicate;
             case CONVENIENCE: // convenience operator, works the same as ">"
             case GREATER:
-                return set -> items.stream().allMatch(item -> set.contains(item));
+                return greaterPredicate;
             default:
                 throw new InvalidPredicateOperatorException();
             }
         } catch (InputMismatchException e) {
             throw new InvalidPredicateTestPhraseException(e);
-        } catch (InvocationTargetWrapperException e) {
-            throw new InvalidPredicateTestPhraseException(e.getCause());
         }
     }
 
     /**
-     * Wrapper class to wrapped the checked InvocationTargetException into an unchecked exception.
-     * It is used to throw the exception through the Stream machinery that is not declared to throw any exception.
+     * Constructs a list of predicates from the given field operator and test phrase that represents a set of values.
+     *
+     * @param klass         The class that the filters are being made for.
+     * @param fieldOperator The set operator for this predicate.
+     * @param testPhrase    The test phrase for this predicate.
+     *
+     * @return The list of predicates that is constructed.
      */
-    private static class InvocationTargetWrapperException extends RuntimeException {
-        public InvocationTargetWrapperException(InvocationTargetException cause) {
-            super(cause);
+    private static <T> List<Predicate<T>> parseTestPhrase(Class<T> klass, FilterOperator fieldOperator,
+                                                          String testPhrase)
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException, IllegalArgumentException {
+        // comma-separated quotable tokenizer
+        StringTokenizer tokenizer = new StringTokenizer(testPhrase,
+            ch -> ch == ',', ch -> ch == '\'' || ch == '\"');
+        List<Predicate<T>> predicates = new ArrayList<>();
+        for (String token : tokenizer.toList()) {
+            token = token.trim();
+            if (token.isEmpty()) {
+                throw new IllegalArgumentException("Tag cannot be empty");
+            }
+            predicates.add(makeFieldPredicate(klass, fieldOperator, token));
         }
-        @Override
-        public InvocationTargetException getCause() {
-            return (InvocationTargetException) super.getCause();
+        return predicates;
+    }
+
+    /**
+     * Constructs a predicate from the given field operator and test phrase.
+     *
+     * @param klass         The class that this filter is being made for.
+     * @param fieldOperator The set operator for this predicate.
+     * @param testPhrase    The test phrase for this predicate.
+     *
+     * @return The predicate that is constructed.
+     */
+    private static <T> Predicate<T> makeFieldPredicate(Class<T> klass, FilterOperator fieldOperator, String testPhrase)
+        throws InvalidPredicateTestPhraseException, InvalidPredicateOperatorException, IllegalArgumentException {
+        assert (testPhrase != null);
+        assert (fieldOperator != null);
+        try {
+            Method method = klass.getMethod("makeFilter", FilterOperator.class, String.class);
+            if ((method.getModifiers() & Modifier.STATIC) == 0) {
+                // method is non-static
+                throw new IllegalArgumentException(
+                    "Class has a non-static makeFilter(FilterOperator, String) method, but we need a static method");
+            }
+            if (method.getReturnType() != Predicate.class) {
+                // method returns the wrong type
+                throw new IllegalArgumentException("Class returns the wrong type");
+            }
+
+            // Note: Unchecked cast because we are using reflection to call the method.
+            @SuppressWarnings("unchecked")
+            Predicate<T> returnPredicate = (Predicate<T>) method.invoke(null, fieldOperator, testPhrase);
+
+            return returnPredicate;
+
+        } catch (InvocationTargetException e) {
+            // this happens when makeFilter() fails
+            if (e.getCause() instanceof InvalidPredicateTestPhraseException) {
+                throw (InvalidPredicateTestPhraseException) e.getCause();
+            } else if (e.getCause() instanceof InvalidPredicateOperatorException) {
+                throw (InvalidPredicateOperatorException) e.getCause();
+            } else {
+                throw new IllegalArgumentException("Unexpected exception thrown by makeFilter()", e.getCause());
+            }
+        } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException e) {
+            throw new IllegalArgumentException(
+                "Class does not have a static makeFilter(FilterOperator, String) method", e);
         }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -168,6 +168,17 @@ public class FilterCommandParserTest {
     }
 
     @Test
+    public void parse_setFilter_doesNotThrow() {
+        assertParseSuccess(parser, "t::x");
+        assertParseSuccess(parser, "t:=x");
+        assertParseSuccess(parser, "t:<x");
+        assertParseSuccess(parser, "t:>x");
+        assertParseSuccess(parser, "t<:x");
+        assertParseSuccess(parser, "t>:x");
+        assertParseSuccess(parser, "t=:xeg4");
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseThrowsException(parser, "d<\"1/10/2018");
         assertParseThrowsException(parser, "d<1/10/2018\"");
@@ -225,6 +236,11 @@ public class FilterCommandParserTest {
         assertParseThrowsException(parser, "(!n:Hello||||!n:World)");
         assertParseThrowsException(parser, "(!n:Hello|||!n:World)");
         assertParseThrowsException(parser, "n:Hello!");
+        assertParseThrowsException(parser, "n::test");
+        assertParseThrowsException(parser, "n=:test");
+        assertParseThrowsException(parser, "n:=test");
+        assertParseThrowsException(parser, "q::test");
+        assertParseThrowsException(parser, "t::1/2/6");
     }
 
     /**


### PR DESCRIPTION
This allows tags to be compared by substring/superstring, so `t:cs` will match all tasks that contain at least one tag that as the substring `cs`.