### PR TITLE
Refractor field identifiers from FilterCommandParser to CliSyntax

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -21,4 +21,18 @@ public class CliSyntax {
 
     /* Prefix definitions for export command */
     public static final Prefix PREFIX_EXPORT_FORMAT = new Prefix("e/");
+
+    public static final String KEY_NAME_SHORT = "n";
+    public static final String KEY_NAME_LONG = "name";
+    public static final String KEY_DEADLINE_SHORT = "d";
+    public static final String KEY_DEADLINE_MEDIUM = "due";
+    public static final String KEY_DEADLINE_LONG = "deadline";
+    public static final String KEY_PRIORITY_SHORT = "p";
+    public static final String KEY_PRIORITY_LONG = "priority";
+    public static final String KEY_FREQUENCY_SHORT = "f";
+    public static final String KEY_FREQUENCY_LONG = "frequency";
+    public static final String KEY_TAG_SHORT = "t";
+    public static final String KEY_TAG_LONG = "tag";
+    public static final String KEY_ATTACHMENT_SHORT = "a";
+    public static final String KEY_ATTACHMENT_LONG = "attachment";
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -19,9 +19,6 @@ public class CliSyntax {
     /* Prefix definitions for import and export command */
     public static final Prefix PREFIX_RESOLVER = new Prefix("r/");
 
-    /* Prefix definitions for export command */
-    public static final Prefix PREFIX_EXPORT_FORMAT = new Prefix("e/");
-
     public static final String KEY_NAME_SHORT = "n";
     public static final String KEY_NAME_LONG = "name";
     public static final String KEY_DEADLINE_SHORT = "d";

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,6 +1,19 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.KEY_NAME_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_NAME_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_MEDIUM;
+import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_PRIORITY_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_PRIORITY_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_FREQUENCY_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_FREQUENCY_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_TAG_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_TAG_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_ATTACHMENT_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_ATTACHMENT_LONG;
 import static seedu.address.ui.ResultDisplay.TEXT_STYLE_CLASS_DEFAULT;
 import static seedu.address.ui.ResultDisplay.TEXT_STYLE_CLASS_ERROR;
 
@@ -51,22 +64,7 @@ import seedu.address.ui.ResultDisplay;
  */
 public class FilterCommandParser implements Parser<FilterCommand> {
 
-    private static final String KEY_NAME_SHORT = "n";
-    private static final String KEY_NAME_LONG = "name";
-    private static final String KEY_DEADLINE_SHORT = "d";
-    private static final String KEY_DEADLINE_MEDIUM = "due";
-    private static final String KEY_DEADLINE_LONG = "deadline";
-    private static final String KEY_PRIORITY_SHORT = "p";
-    private static final String KEY_PRIORITY_LONG = "priority";
-    private static final String KEY_FREQUENCY_SHORT = "f";
-    private static final String KEY_FREQUENCY_LONG = "frequency";
-    private static final String KEY_TAG_SHORT = "t";
-    private static final String KEY_TAG_LONG = "tag";
-    private static final String KEY_ATTACHMENT_SHORT = "a";
-    private static final String KEY_ATTACHMENT_LONG = "attachment";
-
     private static final Predicate<Task> ALWAYS_FALSE = task -> false;
-
 
     // used to match things like:
     // due=1/10/2018
@@ -215,7 +213,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         case KEY_NAME_LONG:
             return createNamePredicate(operator, testPhrase);
         case KEY_DEADLINE_SHORT: // fallthrough
-        case KEY_DEADLINE_MEDIUM:
+        case KEY_DEADLINE_MEDIUM: // fallthrough
         case KEY_DEADLINE_LONG:
             return createDeadlinePredicate(operator, testPhrase);
         case KEY_PRIORITY_SHORT: // fallthrough

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,19 +1,19 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.KEY_NAME_SHORT;
-import static seedu.address.logic.parser.CliSyntax.KEY_NAME_LONG;
-import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_SHORT;
-import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_MEDIUM;
-import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_LONG;
-import static seedu.address.logic.parser.CliSyntax.KEY_PRIORITY_SHORT;
-import static seedu.address.logic.parser.CliSyntax.KEY_PRIORITY_LONG;
-import static seedu.address.logic.parser.CliSyntax.KEY_FREQUENCY_SHORT;
-import static seedu.address.logic.parser.CliSyntax.KEY_FREQUENCY_LONG;
-import static seedu.address.logic.parser.CliSyntax.KEY_TAG_SHORT;
-import static seedu.address.logic.parser.CliSyntax.KEY_TAG_LONG;
-import static seedu.address.logic.parser.CliSyntax.KEY_ATTACHMENT_SHORT;
 import static seedu.address.logic.parser.CliSyntax.KEY_ATTACHMENT_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_ATTACHMENT_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_MEDIUM;
+import static seedu.address.logic.parser.CliSyntax.KEY_DEADLINE_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_FREQUENCY_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_FREQUENCY_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_NAME_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_NAME_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_PRIORITY_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_PRIORITY_SHORT;
+import static seedu.address.logic.parser.CliSyntax.KEY_TAG_LONG;
+import static seedu.address.logic.parser.CliSyntax.KEY_TAG_SHORT;
 import static seedu.address.ui.ResultDisplay.TEXT_STYLE_CLASS_DEFAULT;
 import static seedu.address.ui.ResultDisplay.TEXT_STYLE_CLASS_ERROR;
 


### PR DESCRIPTION
Previously, each field identifier was stored inside FilterCommandParser.  Refractoring it out because it might be shared with SortCommandParser.