### PR TITLE
Remove duplicate check. User can add any task to the deadline manager…

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.task.Task;
 
@@ -35,7 +34,6 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "project";
 
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
-    public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the deadline manager";
 
     private final Task toAdd;
 
@@ -48,12 +46,8 @@ public class AddCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+    public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-
-        if (model.hasTask(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_TASK);
-        }
 
         model.addTask(toAdd);
         model.commitTaskCollection();

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalTasks.getTypicalTaskCollections;
 
@@ -40,10 +39,15 @@ public class AddCommandIntegrationTest {
     }
 
     @Test
-    public void execute_duplicatePerson_throwsCommandException() {
+    public void execute_duplicatePerson_success() {
         Task taskInList = model.getTaskCollection().getTaskList().get(0);
-        assertCommandFailure(new AddCommand(taskInList), model, commandHistory,
-            AddCommand.MESSAGE_DUPLICATE_TASK);
+
+        Model expectedModel = new ModelManager(model.getTaskCollection(), new UserPrefs());
+        expectedModel.addTask(taskInList);
+        expectedModel.commitTaskCollection();
+
+        assertCommandSuccess(new AddCommand(taskInList), model, commandHistory,
+            String.format(AddCommand.MESSAGE_SUCCESS, taskInList), expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ReadOnlyTaskCollection;
 import seedu.address.model.TaskCollection;
 import seedu.address.model.task.Task;
@@ -48,14 +47,17 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_duplicatePerson_throwsCommandException() throws Exception {
+    public void execute_duplicatePerson_addSuccessful() {
         Task validTask = new TaskBuilder().build();
         AddCommand addCommand = new AddCommand(validTask);
-        ModelStub modelStub = new ModelStubWithPerson(validTask);
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+        modelStub.addTask(validTask);
 
-        thrown.expect(CommandException.class);
-        thrown.expectMessage(AddCommand.MESSAGE_DUPLICATE_TASK);
-        addCommand.execute(modelStub, commandHistory);
+        CommandResult commandResult = new AddCommand(validTask).execute(modelStub, commandHistory);
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validTask),
+            commandResult.feedbackToUser);
+        assertEquals(Arrays.asList(validTask, validTask), modelStub.tasksAdded);
+        assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
     }
 
     @Test

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -19,7 +19,6 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_FREQUENCY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_BOB;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.task.Frequency.NO_FREQUENCY;
 import static seedu.address.model.task.Priority.NO_PRIORITY;
 import static seedu.address.testutil.TypicalTasks.ALICE;
@@ -134,15 +133,16 @@ public class AddCommandSystemTest extends TaskCollectionSystemTest {
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a duplicate task except with different tags -> added normally */
-        command = TaskUtil.getAddCommand(HOON) + " " + PREFIX_TAG.getPrefix() + "friends";
         toAdd = new TaskBuilder(HOON).withTags("friends").build();
+        command = TaskUtil.getAddCommand(toAdd);// + " " + PREFIX_TAG.getPrefix() + "friends";
+        assertCommandSuccess(command, toAdd);
+
+        /* Case: add a duplicate task with everything the same -> added normally */
+        toAdd = HOON;
+        command = TaskUtil.getAddCommand(toAdd);
         assertCommandSuccess(command, toAdd);
 
         /* ----------------------------------- Perform invalid add operations --------------------------------------- */
-
-        /* Case: add a duplicate task -> rejected */
-        command = TaskUtil.getAddCommand(HOON);
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_TASK);
 
         /* Case: missing name -> rejected */
         command = AddCommand.COMMAND_WORD + PRIORITY_DESC_AMY + FREQUENCY_DESC_AMY + DEADLINE_DESC_AMY;


### PR DESCRIPTION
…, even if the same task currently exists.

Resolves #245 