### PR TITLE
Allow spaces for tags in sort command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -131,11 +131,12 @@ public class SortCommandParser implements Parser<SortCommand> {
                 tags = tags.substring(1, tags.length() - 1); // removing '{' and '}'
 
                 String[] tagsOrder = tags.split("~+");
-                tagsOrder = Arrays.asList(tagsOrder)    // to remove empty strings
+                tagsOrder = Arrays.asList(tagsOrder)
                         .stream()
                         .filter(str -> !str.isEmpty())
                         .collect(Collectors.toList())
                         .toArray(new String[0]);
+                // ^to remove empty strings
 
                 if (comparisonCharacter == '>') {
                     tagsOrder = reverseString(tagsOrder);

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.SimpleParseException;
@@ -129,6 +131,12 @@ public class SortCommandParser implements Parser<SortCommand> {
                 tags = tags.substring(1, tags.length() - 1); // removing '{' and '}'
 
                 String[] tagsOrder = tags.split("~+");
+                tagsOrder = Arrays.asList(tagsOrder)    // to remove empty strings
+                        .stream()
+                        .filter(str -> !str.isEmpty())
+                        .collect(Collectors.toList())
+                        .toArray(new String[0]);
+
                 if (comparisonCharacter == '>') {
                     tagsOrder = reverseString(tagsOrder);
                 }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -28,6 +28,7 @@ public class SortCommandParserTest {
         assertParseSuccess(parser, "d> d<");
         assertParseSuccess(parser, "p< due>");
         assertParseSuccess(parser, "p< tag<{cs2103t  cs2030 easy}");
+        assertParseSuccess(parser, "p< tag<{ cs2103t  cs2030 easy }");
         assertParseSuccess(parser, "f< n>");
     }
 
@@ -38,8 +39,9 @@ public class SortCommandParserTest {
         assertParseThrowsException(parser, "name>>");
         assertParseThrowsException(parser, "name>>  due<");
         assertParseThrowsException(parser, "name~");
-        assertParseThrowsException(parser, "p< tag<{ cs2103t  cs2030 easy}");
         assertParseThrowsException(parser, "p< tag<{ cs2103t  cs2030 easy}}");
+        assertParseThrowsException(parser, "p< tag<");
+        assertParseThrowsException(parser, "p< tag<{");
         assertParseThrowsException(parser, "frequencies<");
     }
 


### PR DESCRIPTION
Fixes #119 (Up to a certain extent)
Allows arbitrary whitespaces.
Still does not allow dropping of curly braces.